### PR TITLE
Fix yscale out of bounds rounding error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,13 @@
 /output/fceux.exp
 /output/fceux.lib
 /output/fceux.cfg
+
+# build output
+bin
+src/fceux
+fceux-net-server
+*.o
+.sconf_temp/
+.sconsign.dblite
+.deps
+.dirstamp

--- a/src/attic/pc/sdl-video.c
+++ b/src/attic/pc/sdl-video.c
@@ -174,7 +174,7 @@ int InitVideo(FCEUGI *gi)
   #ifdef OPENGL
   if( (usingogl && !_stretchy) || !usingogl)
   #endif
-   if(_yres<tlines*eys || eys <= 0.01)
+   if(_yres < (int)(tlines*eys) || eys <= 0.01)
    {
     FCEUD_PrintError("yscale out of bounds.");
     KillVideo();

--- a/src/drivers/sdl/sdl-video.cpp
+++ b/src/drivers/sdl/sdl-video.cpp
@@ -319,7 +319,7 @@ InitVideo(FCEUGI *gi)
 #ifdef OPENGL
 		if((s_useOpenGL && !ystretch) || !s_useOpenGL)
 #endif
-			if(yres < s_tlines * s_eys || s_eys <= 0.01) {
+			if(yres < int(s_tlines * s_eys) || s_eys <= 0.01) {
 				FCEUD_PrintError("yscale out of bounds.");
 				KillVideo();
 				return -1;


### PR DESCRIPTION
When toggling full screen mode on Linux, it displays an error message stating the the y scale is out of bounds. This PR fixes that by fixing the rounding error that results from the y scale calculations.