### PR TITLE
fix: UTF8 is NOT really UTF8

### DIFF
--- a/src/cart.cpp
+++ b/src/cart.cpp
@@ -356,7 +356,7 @@ bool FCEU_OpenGenie(void)
 			return true;
 
 		fn = strdup(FCEU_MakeFName(FCEUMKF_GGROM, 0, 0).c_str());
-		fp = FCEUD_UTF8fopen(fn, "rb");
+		fp = FCEUD_fopen(fn, "rb");
 		if (!fp)
 		{
 			FCEU_PrintError("Error opening Game Genie ROM image!\nIt should be named \"gg.rom\"!");
@@ -536,7 +536,7 @@ void FCEU_SaveGameSave(CartInfo *LocalHWInfo) {
 		FILE *sp;
 
 		std::string soot = FCEU_MakeFName(FCEUMKF_SAV, 0, "sav");
-		if ((sp = FCEUD_UTF8fopen(soot, "wb")) == NULL) {
+		if ((sp = FCEUD_fopen(soot, "wb")) == NULL) {
 			FCEU_PrintError("WRAM file \"%s\" cannot be written to.\n", soot.c_str());
 		} else {
 			for (int x = 0; x < 4; x++)
@@ -556,7 +556,7 @@ void FCEU_LoadGameSave(CartInfo *LocalHWInfo) {
 		FILE *sp;
 
 		std::string soot = FCEU_MakeFName(FCEUMKF_SAV, 0, "sav");
-		sp = FCEUD_UTF8fopen(soot, "rb");
+		sp = FCEUD_fopen(soot, "rb");
 		if (sp != NULL) {
 			for (int x = 0; x < 4; x++)
 				if (LocalHWInfo->SaveGame[x])

--- a/src/cheat.cpp
+++ b/src/cheat.cpp
@@ -210,7 +210,7 @@ void FCEU_LoadGameCheats(FILE *override)
 	else
 	{
 		fn=strdup(FCEU_MakeFName(FCEUMKF_CHEAT,0,0).c_str());
-		fp=FCEUD_UTF8fopen(fn,"rb");
+		fp=FCEUD_fopen(fn,"rb");
 		free(fn);
 		if(!fp) return;
 	}
@@ -319,7 +319,7 @@ void FCEU_FlushGameCheats(FILE *override, int nosave)
 			if(override)
 				fp = override;
 			else
-				fp=FCEUD_UTF8fopen(fn,"wb");
+				fp=FCEUD_fopen(fn,"wb");
 
 			if(fp)
 			{

--- a/src/driver.h
+++ b/src/driver.h
@@ -9,10 +9,10 @@
 #include <cstring>
 #include <iosfwd>
 
-FILE *FCEUD_UTF8fopen(const char *fn, const char *mode);
-inline FILE *FCEUD_UTF8fopen(const std::string &n, const char *mode) { return FCEUD_UTF8fopen(n.c_str(),mode); }
-EMUFILE_FILE* FCEUD_UTF8_fstream(const char *n, const char *m);
-inline EMUFILE_FILE* FCEUD_UTF8_fstream(const std::string &n, const char *m) { return FCEUD_UTF8_fstream(n.c_str(),m); }
+FILE *FCEUD_fopen(const char *fn, const char *mode);
+inline FILE *FCEUD_fopen(const std::string &n, const char *mode) { return FCEUD_fopen(n.c_str(),mode); }
+EMUFILE_FILE* FCEUD_fstream(const char *n, const char *m);
+inline EMUFILE_FILE* FCEUD_fstream(const std::string &n, const char *m) { return FCEUD_fstream(n.c_str(),m); }
 FCEUFILE* FCEUD_OpenArchiveIndex(ArchiveScanRecord& asr, std::string& fname, int innerIndex);
 FCEUFILE* FCEUD_OpenArchive(ArchiveScanRecord& asr, std::string& fname, std::string* innerFilename);
 ArchiveScanRecord FCEUD_ScanArchive(std::string fname);
@@ -342,10 +342,5 @@ enum EFCEUI
 
 //checks whether an EFCEUI is valid right now
 bool FCEU_IsValidUI(EFCEUI ui);
-
-#ifdef __cplusplus
-extern "C"
-#endif
-FILE *FCEUI_UTF8fopen_C(const char *n, const char *m);
 
 #endif //__DRIVER_H_

--- a/src/drivers/win/archive.cpp
+++ b/src/drivers/win/archive.cpp
@@ -200,7 +200,7 @@ public:
 	InFileStream(std::string fname)
 	: inf(0)
 	{
-		inf = FCEUD_UTF8_fstream(fname,"rb");
+		inf = FCEUD_fstream(fname,"rb");
 		if(inf)
 		{
 			size = inf->size();
@@ -399,7 +399,7 @@ ArchiveScanRecord FCEUD_ScanArchive(std::string fname)
 	}
 
 	//check the file against the signatures
-	EMUFILE* inf = FCEUD_UTF8_fstream(fname,"rb");
+	EMUFILE* inf = FCEUD_fstream(fname,"rb");
 	if(!inf) return ArchiveScanRecord();
 
 	int matchingFormat = -1;

--- a/src/drivers/win/aviout.cpp
+++ b/src/drivers/win/aviout.cpp
@@ -77,7 +77,7 @@ static bool use_sound=false;
 static int truncate_existing(const char* filename)
 {
 	// this is only here because AVIFileOpen doesn't seem to do it for us
-	FILE* fd = FCEUD_UTF8fopen(filename, "wb");
+	FILE* fd = FCEUD_fopen(filename, "wb");
 	if(fd)
 	{
 		fclose(fd);

--- a/src/drivers/win/cheat.cpp
+++ b/src/drivers/win/cheat.cpp
@@ -573,7 +573,7 @@ BOOL CALLBACK CheatConsoleCallB(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM l
 
 							if (GetOpenFileName(&ofn))
 							{
-								FILE* file = FCEUD_UTF8fopen(nameo, "rb");
+								FILE* file = FCEUD_fopen(nameo, "rb");
 								if (file)
 								{
 									FCEU_LoadGameCheats(file);

--- a/src/drivers/win/input.cpp
+++ b/src/drivers/win/input.cpp
@@ -1716,7 +1716,7 @@ static void PresetExport(int preset)
 			InputPresetDir[ofn.nFileOffset]=0;
 		}
 
-		FILE *fp=FCEUD_UTF8fopen(nameo,"w");
+		FILE *fp=FCEUD_fopen(nameo,"w");
 		switch(preset)
 		{
 		case 1: fwrite(GamePadPreset1,1,sizeof(GamePadPreset1),fp); break;
@@ -1755,7 +1755,7 @@ static void PresetImport(int preset)
 			InputPresetDir[ofn.nFileOffset]=0;
 		}
 
-		FILE *fp=FCEUD_UTF8fopen(nameo,"r");
+		FILE *fp=FCEUD_fopen(nameo,"r");
 		switch(preset)
 		{
 		case 1: fread(GamePadPreset1,1,sizeof(GamePadPreset1),fp); break;

--- a/src/drivers/win/main.cpp
+++ b/src/drivers/win/main.cpp
@@ -1046,7 +1046,7 @@ static void FCEUD_MakePathDirs(const char *fname)
 	} while(1);
 }
 
-EMUFILE_FILE* FCEUD_UTF8_fstream(const char *n, const char *m)
+EMUFILE_FILE* FCEUD_fstream(const char *n, const char *m)
 {
 	if(strchr(m, 'w') || strchr(m, '+'))
 	{
@@ -1060,7 +1060,7 @@ EMUFILE_FILE* FCEUD_UTF8_fstream(const char *n, const char *m)
 	} else return fs;
 }
 
-FILE *FCEUD_UTF8fopen(const char *n, const char *m)
+FILE *FCEUD_fopen(const char *n, const char *m)
 {
 	if(strchr(m, 'w') || strchr(m, '+'))
 	{

--- a/src/drivers/win/memwatch.cpp
+++ b/src/drivers/win/memwatch.cpp
@@ -441,7 +441,7 @@ static void SaveMemWatch()
 		strcpy(memwLastFilename,nameo);
 
 		SaveStrings();
-		FILE *fp=FCEUD_UTF8fopen(memwLastFilename,"w");
+		FILE *fp=FCEUD_fopen(memwLastFilename,"w");
 		for(i=0;i<NUMWATCHES;i++)
 		{
 			//Use dummy strings to fill empty slots
@@ -472,7 +472,7 @@ static void QuickSaveMemWatch() //Save rather than Save as
 	if (memwLastFilename[0]!=NULL) // Check if there is there something to save else default to save as
 	{
 		SaveStrings();
-		FILE *fp=FCEUD_UTF8fopen(memwLastFilename,"w");
+		FILE *fp=FCEUD_fopen(memwLastFilename,"w");
 		for(int i=0;i<NUMWATCHES;i++)
 		{
 			//Use dummy strings to fill empty slots
@@ -538,7 +538,7 @@ static void LoadMemWatch()
 			MemWatchDir[ofn.nFileOffset]=0;
 		}
 			
-		FILE *fp=FCEUD_UTF8fopen(memwLastFilename,"r");
+		FILE *fp=FCEUD_fopen(memwLastFilename,"r");
 			MemwAddRecentFile(memwLastFilename);
 
 		for(i=0;i<NUMWATCHES;i++)
@@ -584,7 +584,7 @@ void OpenMemwatchRecentFile(int memwRFileNumber)
 	if (x == NULL) return; //If no recent files exist just return.  Useful for Load last file on startup (or if something goes screwy)
 	char watchfcontents[2048];
 
-	FILE *fp=FCEUD_UTF8fopen(x,"r");	//Open the recent file
+	FILE *fp=FCEUD_fopen(x,"r");	//Open the recent file
 	if (fp)		//Check if file opening was successful, if not, abort
 	{
 		strcpy(memwLastFilename,x);

--- a/src/drivers/win/palette.cpp
+++ b/src/drivers/win/palette.cpp
@@ -16,7 +16,7 @@ extern bool paldeemphswap;
 bool SetPalette(const char* nameo)
 {
 	FILE *fp;
-	if((fp = FCEUD_UTF8fopen(nameo, "rb")))
+	if((fp = FCEUD_fopen(nameo, "rb")))
 	{
 		int readed = fread(cpalette, 1, sizeof(cpalette), fp);
 		fclose(fp);

--- a/src/drivers/win/taseditor.cpp
+++ b/src/drivers/win/taseditor.cpp
@@ -805,7 +805,7 @@ void exportToFM2()
 		ofn.lpstrInitialDir = initdir.c_str();
 		if (GetSaveFileName(&ofn))
 		{
-			EMUFILE* osRecordingMovie = FCEUD_UTF8_fstream(fname, "wb");
+			EMUFILE* osRecordingMovie = FCEUD_fstream(fname, "wb");
 			// create copy of current movie data
 			MovieData temp_md = currMovieData;
 			// modify the copy according to selected type of export

--- a/src/drivers/win/taseditor/taseditor_project.cpp
+++ b/src/drivers/win/taseditor/taseditor_project.cpp
@@ -117,9 +117,9 @@ bool TASEDITOR_PROJECT::save(const char* differentName, bool inputInBinary, bool
 	// open file for write
 	EMUFILE_FILE* ofs = 0;
 	if (differentName)
-		ofs = FCEUD_UTF8_fstream(differentName, "wb");
+		ofs = FCEUD_fstream(differentName, "wb");
 	else
-		ofs = FCEUD_UTF8_fstream(getProjectFile().c_str(), "wb");
+		ofs = FCEUD_fstream(getProjectFile().c_str(), "wb");
 	if (ofs)
 	{
 		// change cursor to hourglass

--- a/src/drivers/win/window.cpp
+++ b/src/drivers/win/window.cpp
@@ -318,7 +318,7 @@ static void ConvertFCM(HWND hwndOwner)
 			if(result==FCM_CONVERTRESULT_SUCCESS)
 			{
 				okcount++;
-				EMUFILE_FILE* outf = FCEUD_UTF8_fstream(outname, "wb");
+				EMUFILE_FILE* outf = FCEUD_fstream(outname, "wb");
 				md.dump(outf,false);
 				delete outf;
 			} else {
@@ -1105,7 +1105,11 @@ bool ALoad(const char *nameo, char* innerFilename, bool silent)
 /// @param initialdir Directory that's pre-selected in the Open File dialog.
 void LoadNewGamey(HWND hParent, const char *initialdir)
 {
-	const char filter[] = "All usable files (*.nes,*.nsf,*.fds,*.unf,*.zip,*.rar,*.7z,*.gz)\0*.nes;*.nsf;*.fds;*.unf;*.zip;*.rar;*.7z;*.gz\0All non-compressed usable files (*.nes,*.nsf,*.fds,*.unf)\0*.nes;*.nsf;*.fds;*.unf\0All Files (*.*)\0*.*\0\0";
+	const char filter[] =
+		"All usable files (*.nes,*.nsf,*.fds,*.unf,*.zip,*.rar,*.7z,*.gz)\0*.nes;*.nsf;*.fds;*.unf;*.zip;*.rar;*.7z;*.gz\0"
+		"All non-compressed usable files (*.nes,*.nsf,*.fds,*.unf)\0*.nes;*.nsf;*.fds;*.unf\0"
+		"All Files (*.*)\0*.*\0"
+		"\0";
 	char nameo[2048];
 
 	// Create the Open File dialog
@@ -1523,7 +1527,7 @@ LRESULT FAR PASCAL AppWndProc(HWND hWnd,UINT msg,WPARAM wParam,LPARAM lParam)
 				//-------------------------------------------------------
 				if (!(fileDropped.find(".cht") == string::npos) && (fileDropped.find(".cht") == fileDropped.length()-4))
 				{
-					FILE* file = FCEUD_UTF8fopen(fileDropped.c_str(),"rb");
+					FILE* file = FCEUD_fopen(fileDropped.c_str(),"rb");
 					FCEU_LoadGameCheats(file);
 				}
 				
@@ -1544,7 +1548,7 @@ LRESULT FAR PASCAL AppWndProc(HWND hWnd,UINT msg,WPARAM wParam,LPARAM lParam)
 					EFCM_CONVERTRESULT result = convert_fcm(md, fileDropped.c_str());
 					if(result==FCM_CONVERTRESULT_SUCCESS)
 					{
-						EMUFILE* outf = FCEUD_UTF8_fstream(outname, "wb");
+						EMUFILE* outf = FCEUD_fstream(outname, "wb");
 						md.dump(outf,false);
 						delete outf;
 						if (!GameInfo)				//If no game is loaded, load the Open Game dialog

--- a/src/emufile.cpp
+++ b/src/emufile.cpp
@@ -66,6 +66,9 @@ void EMUFILE_FILE::open(const char* fname, const char* mode)
 	if(!fp)
 	{
 #ifdef _MSC_VER
+		// fname can be either UTF-8(Linux/macOS) or Extended-ASCII(Windows) like Chinese.
+		// BUT, mbstowcs does conversion from UTF-8 to UNICODE-16 only.
+		// It really works?
 		std::wstring wfname = mbstowcs((std::string)fname);
 		std::wstring wfmode = mbstowcs((std::string)mode);
 		fp = _wfopen(wfname.c_str(),wfmode.c_str());

--- a/src/fceu.cpp
+++ b/src/fceu.cpp
@@ -254,11 +254,6 @@ int AutosaveFrequency = 256; // Number of frames between autosaves
 // Flag that indicates whether the Auto-save option is enabled or not
 int EnableAutosave = 0;
 
-///a wrapper for unzip.c
-extern "C" FILE *FCEUI_UTF8fopen_C(const char *n, const char *m) {
-	return ::FCEUD_UTF8fopen(n, m);
-}
-
 static DECLFW(BNull) {
 }
 

--- a/src/fds.cpp
+++ b/src/fds.cpp
@@ -640,7 +640,7 @@ int FDSLoad(const char *name, FCEUFILE *fp) {
 
 	char *fn = strdup(FCEU_MakeFName(FCEUMKF_FDSROM, 0, 0).c_str());
 
-	if (!(zp = FCEUD_UTF8fopen(fn, "rb"))) {
+	if (!(zp = FCEUD_fopen(fn, "rb"))) {
 		FCEU_PrintError("FDS BIOS ROM image missing: %s", FCEU_MakeFName(FCEUMKF_FDSROM, 0, 0).c_str());
 		free(fn);
 		return 0;
@@ -777,7 +777,7 @@ void FDSClose(void) {
 	if (!DiskWritten) return;
 
 	const std::string &fn = FCEU_MakeFName(FCEUMKF_FDS, 0, 0);
-	if (!(fp = FCEUD_UTF8fopen(fn.c_str(), "wb"))) {
+	if (!(fp = FCEUD_fopen(fn.c_str(), "wb"))) {
 		return;
 	}
 

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -275,7 +275,7 @@ FCEUFILE * FCEU_fopen(const char *path, const char *ipsfn, char *mode, char *ext
 
 	//try to setup the ips file
 	if(ipsfn && read)
-		ipsfile=FCEUD_UTF8fopen(ipsfn,"rb");
+		ipsfile=FCEUD_fopen(ipsfn,"rb");
 	if(read)
 	{
 		ArchiveScanRecord asr = FCEUD_ScanArchive(fileToOpen);
@@ -283,7 +283,7 @@ FCEUFILE * FCEU_fopen(const char *path, const char *ipsfn, char *mode, char *ext
 		if(!asr.isArchive())
 		{
 			//if the archive contained no files, try to open it the old fashioned way
-			EMUFILE_FILE* fp = FCEUD_UTF8_fstream(fileToOpen,mode);
+			EMUFILE_FILE* fp = FCEUD_fstream(fileToOpen,mode);
 			if(!fp || (fp->get_fp() == NULL))
 			{
 				return 0;
@@ -371,7 +371,7 @@ FCEUFILE * FCEU_fopen(const char *path, const char *ipsfn, char *mode, char *ext
 	applyips:
 		//try to open the ips file
 		if(!ipsfile && !ipsfn)
-			ipsfile=FCEUD_UTF8fopen(FCEU_MakeIpsFilename(DetermineFileBase(fceufp->logicalPath.c_str())),"rb");
+			ipsfile=FCEUD_fopen(FCEU_MakeIpsFilename(DetermineFileBase(fceufp->logicalPath.c_str())),"rb");
 		ApplyIPS(ipsfile,fceufp);
 		return fceufp;
 	}

--- a/src/movie.cpp
+++ b/src/movie.cpp
@@ -1023,7 +1023,7 @@ bool FCEUI_LoadMovie(const char *fname, bool _read_only, int _pauseframe)
 
 static void openRecordingMovie(const char* fname)
 {
-	osRecordingMovie = FCEUD_UTF8_fstream(fname, "wb");
+	osRecordingMovie = FCEUD_fstream(fname, "wb");
 	if(!osRecordingMovie)
 		FCEU_PrintError("Error opening movie output file: %s",fname);
 	strcpy(curMovieFilename, fname);
@@ -1735,7 +1735,7 @@ void FCEU_DisplaySubtitles(char *format, ...)
 void FCEUI_CreateMovieFile(std::string fn)
 {
 	MovieData md = currMovieData;							//Get current movie data
-	EMUFILE* outf = FCEUD_UTF8_fstream(fn, "wb");		//open/create file
+	EMUFILE* outf = FCEUD_fstream(fn, "wb");		//open/create file
 	md.dump(outf,false);									//dump movie data
 	delete outf;											//clean up, delete file object
 }

--- a/src/netplay.cpp
+++ b/src/netplay.cpp
@@ -117,7 +117,7 @@ int FCEUNET_SendFile(uint8 cmd, char *fn)
 	FILE *fp;
 	struct stat sb;
 
-	if(!(fp=FCEUD_UTF8fopen(fn,"rb"))) return(0);
+	if(!(fp=FCEUD_fopen(fn,"rb"))) return(0);
 
 	FCEUX_fstat(fileno(fp),&sb);
 	len = sb.st_size;

--- a/src/oldmovie.cpp
+++ b/src/oldmovie.cpp
@@ -107,7 +107,7 @@ static void FCEUI_LoadMovie_v1(char *fname, int _read_only);
 //		uint32 version;
 //		uint8 _flags[4];
 //
-//		FILE* fp = FCEUD_UTF8fopen(fname, "rb");
+//		FILE* fp = FCEUD_fopen(fname, "rb");
 //		if(!fp)
 //			return 0;
 //
@@ -267,7 +267,7 @@ uint16 metadata_ucs2[];     // ucs-2, ick!  sizeof(metadata) = offset_to_savesta
 //	if(access(fname, W_OK))
 //		movie_readonly = 2;
 //
-//	fp = FCEUD_UTF8fopen(fname, (movie_readonly>=2) ? "rb" : "r+b");
+//	fp = FCEUD_fopen(fname, (movie_readonly>=2) ? "rb" : "r+b");
 //
 //	if(fn)
 //	{
@@ -362,7 +362,7 @@ uint16 metadata_ucs2[];     // ucs-2, ick!  sizeof(metadata) = offset_to_savesta
 //	uint8 tmp[MOVIE_MAX_METADATA<<1];
 //	int metadata_length;
 //
-//	FILE* fp = FCEUD_UTF8fopen(fname, "rb");
+//	FILE* fp = FCEUD_fopen(fname, "rb");
 //	if(!fp)
 //		return 0;
 //
@@ -542,7 +542,7 @@ EFCM_CONVERTRESULT convert_fcm(MovieData& md, std::string fname)
 	int movieConvertOffset1=0, movieConvertOffset2=0,movieSyncHackOn=0;
 
 
-	EMUFILE* fp = FCEUD_UTF8_fstream(fname, "rb");
+	EMUFILE* fp = FCEUD_fstream(fname, "rb");
 	if(!fp) return FCM_CONVERTRESULT_FAILOPEN;
 
 	// read header

--- a/src/palette.cpp
+++ b/src/palette.cpp
@@ -311,7 +311,7 @@ void FCEU_LoadGamePalette(void)
 {
 	palette_game_available = false;
 	std::string path = FCEU_MakeFName(FCEUMKF_PALETTE,0,0);
-	FILE* fp = FCEUD_UTF8fopen(path,"rb");
+	FILE* fp = FCEUD_fopen(path,"rb");
 	if(fp)
 	{
 		int readed = fread(palette_game,1,64*8*3,fp);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -465,7 +465,7 @@ void FCEUSS_Save(const char *fname, bool display_message)
 
 	if(fname)	//If filename is given use it.
 	{
-		st = FCEUD_UTF8_fstream(fname, "wb");
+		st = FCEUD_fstream(fname, "wb");
 		strcpy(fn, fname);
 	}
 	else		//Else, generate one
@@ -483,7 +483,7 @@ void FCEUSS_Save(const char *fname, bool display_message)
 		else
 			undoSS = false;					//so backup made so lastSavestateMade does have a backup file, so no undo
 
-		st = FCEUD_UTF8_fstream(fn,"wb");
+		st = FCEUD_fstream(fn,"wb");
 	}
 
 	if (st == NULL || st->get_fp() == NULL)
@@ -729,12 +729,12 @@ bool FCEUSS_Load(const char *fname, bool display_message)
 	}
 	if (fname)
 	{
-		st = FCEUD_UTF8_fstream(fname, "rb");
+		st = FCEUD_fstream(fname, "rb");
 		strcpy(fn, fname);
 	} else
 	{
 		strcpy(fn, FCEU_MakeFName(FCEUMKF_STATE,CurrentState,fname).c_str());
-		st=FCEUD_UTF8_fstream(fn,"rb");
+		st=FCEUD_fstream(fn,"rb");
         strcpy(lastLoadstateMade,fn);
 	}
 
@@ -827,7 +827,7 @@ void FCEUSS_CheckStates(void)
 
 	for(ssel=0;ssel<10;ssel++)
 	{
-		st=FCEUD_UTF8fopen(FCEU_MakeFName(FCEUMKF_STATE,ssel,0),"rb");
+		st=FCEUD_fopen(FCEU_MakeFName(FCEUMKF_STATE,ssel,0),"rb");
 		if(st)
 		{
 			SaveStateStatus[ssel]=1;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -576,13 +576,13 @@ int SaveSnapshot(void)
 
 	for (u = lastu; u < 99999; ++u)
 	{
-		pp=FCEUD_UTF8fopen(FCEU_MakeFName(FCEUMKF_SNAP,u,"png").c_str(),"rb");
+		pp=FCEUD_fopen(FCEU_MakeFName(FCEUMKF_SNAP,u,"png").c_str(),"rb");
 		if(pp==NULL) break;
 		fclose(pp);
 	}
 	lastu = u;
 
-	if(!(pp=FCEUD_UTF8fopen(FCEU_MakeFName(FCEUMKF_SNAP,u,"png").c_str(),"wb")))
+	if(!(pp=FCEUD_fopen(FCEU_MakeFName(FCEUMKF_SNAP,u,"png").c_str(),"wb")))
 	{
 		free(compmem);
 		return 0;
@@ -674,7 +674,7 @@ int SaveSnapshot(char fileName[512])
 	if(!(compmem=(uint8 *)FCEU_malloc(compmemsize)))
 		return 0;
 
-	if(!(pp=FCEUD_UTF8fopen(fileName,"wb")))
+	if(!(pp=FCEUD_fopen(fileName,"wb")))
 	{
 		free(compmem);
 		return 0;

--- a/src/wave.cpp
+++ b/src/wave.cpp
@@ -83,7 +83,7 @@ bool FCEUI_BeginWaveRecord(const char *fn)
 {
  int r;
 
- if(!(soundlog=FCEUD_UTF8fopen(fn,"wb")))
+ if(!(soundlog=FCEUD_fopen(fn,"wb")))
   return false;
  wsize=0;
 


### PR DESCRIPTION
It often confuses me that function like `FCEUD_UTF8fopen` accepts a `char*` as filename instead of `wchar_t*`. It does work on Linux/macOS. But on Windows, the `A-ed` version of Windows API  like `GetOpenFileNameA` does return an Extended-ASCII string, NOT UTF8. At this time, the `utf8` part in function name is incorrect. They do not expect to accept a UTF8 string.