### PR TITLE
Make it compile against SDL2

### DIFF
--- a/src/drivers/sdl/gui.cpp
+++ b/src/drivers/sdl/gui.cpp
@@ -1988,7 +1988,7 @@ unsigned short GDKToSDLKeyval(int gdk_key)
 	}
 	
 	// Non-ASCII symbol.
-	static const uint16_t gdk_to_sdl_table[0x100] =
+	static const unsigned int gdk_to_sdl_table[0x100] =
 	{
 		// 0x00 - 0x0F
 		0x0000, 0x0000, 0x0000, 0x0000,

--- a/src/drivers/sdl/input.h
+++ b/src/drivers/sdl/input.h
@@ -7,7 +7,7 @@
 typedef struct {
 	uint8  ButtType[MAXBUTTCONFIG];
 	uint8  DeviceNum[MAXBUTTCONFIG];
-	uint16 ButtonNum[MAXBUTTCONFIG];
+	int ButtonNum[MAXBUTTCONFIG];
 	uint32 NumC;
 	//uint64 DeviceID[MAXBUTTCONFIG];	/* TODO */
 } ButtConfig;

--- a/src/drivers/sdl/sdl-opengl.cpp
+++ b/src/drivers/sdl/sdl-opengl.cpp
@@ -21,6 +21,11 @@
 #define APIENTRY
 #endif
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+#define SDL_FULLSCREEN SDL_WINDOW_FULLSCREEN
+#define SDL_GL_SwapBuffers() SDL_GL_SwapWindow(NULL)
+#endif
+
 static GLuint textures[2]={0,0};	// Normal image, scanline overlay.
 
 static int left,right,top,bottom; // right and bottom are not inclusive.


### PR DESCRIPTION
When I had read that SDL2 support was experimental/nonfunctional, I didn't know that meant uncompilable.  Well, I made it compilable at least.