### PR TITLE
gtk: fix audio going on/off when entering Sound Config option

### DIFF
--- a/src/drivers/sdl/gui.cpp
+++ b/src/drivers/sdl/gui.cpp
@@ -1330,8 +1330,10 @@ void toggleSound(GtkWidget* check, gpointer data)
 {
 	if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(check)))
 	{
+		int last_soundopt;
+		g_config->getOption("SDL.Sound", &last_soundopt);
 		g_config->setOption("SDL.Sound", 1);
-		if(GameInfo)		
+		if(GameInfo && !last_soundopt)
 			InitSound();
 	}
 	else


### PR DESCRIPTION
Adds check if sound was already enabled and only then only call
InitSound() when it was not enabled. This seems to be a better option
than calling KillSound() which causes unnecessary audio pop when you
are just entering the menu and not adjusting stuff yet.