### PR TITLE
Some ui interface logic changes and improvements.

### DIFF
--- a/src/cheat.cpp
+++ b/src/cheat.cpp
@@ -964,3 +964,20 @@ void UpdateFrozenList(void)
 	}
 	//FCEUI_DispMessage("FrozenCount: %d",0,FrozenAddressCount);//Debug
 }
+
+// disable all cheats
+int FCEU_DisableAllCheats(){
+	int count = 0;
+	struct CHEATF *next=cheats;
+	while(next)
+	{
+		if(next->status){
+			count++;
+		}
+		next->status = 0;
+		next = next->next;
+	}
+	savecheats=1;
+	RebuildSubCheats();
+	return count;
+}

--- a/src/cheat.h
+++ b/src/cheat.h
@@ -10,3 +10,5 @@ int FCEU_CheatGetByte(uint32 A);
 void FCEU_CheatSetByte(uint32 A, uint8 V);
 
 extern int savecheats;
+
+int FCEU_DisableAllCheats();

--- a/src/drivers/win/archive.cpp
+++ b/src/drivers/win/archive.cpp
@@ -275,6 +275,9 @@ public:
 	}
 };
 
+// indicator for the open in archive dialog that if the load was canceled by the user.
+// TODO: Since I can't think of a better way to indicate it, hope someone could imporve it.
+bool archiveManuallyCanceled;
 
 static BOOL CALLBACK ArchiveFileSelectorCallback(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -282,6 +285,8 @@ static BOOL CALLBACK ArchiveFileSelectorCallback(HWND hwndDlg, UINT uMsg, WPARAM
 	{
 	case WM_INITDIALOG:
 		{
+			// TODO: find a better way to do this.
+			archiveManuallyCanceled = false;
 			HWND hwndListbox = GetDlgItem(hwndDlg,IDC_LIST1);
 			for(uint32 i=0;i<currFileSelectorContext->size();i++)
 			{
@@ -307,6 +312,9 @@ static BOOL CALLBACK ArchiveFileSelectorCallback(HWND hwndDlg, UINT uMsg, WPARAM
 
 			case IDCANCEL:
 				EndDialog(hwndDlg, LB_ERR);
+				// Tell the parent window that the operation was canceled rather than loading error
+				// TODO: find a better way to do this.
+				archiveManuallyCanceled = true;
 				return TRUE;
 		}
 		break;

--- a/src/drivers/win/cheat.cpp
+++ b/src/drivers/win/cheat.cpp
@@ -901,6 +901,7 @@ BOOL CALLBACK GGConvCallB(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 									EnableWindow(GetDlgItem(hCheat,IDC_BTN_CHEAT_DEL),TRUE);
 									EnableWindow(GetDlgItem(hCheat,IDC_BTN_CHEAT_UPD),TRUE);
+									UpdateCheatsAdded();
 								}
 						}
 					break;
@@ -1027,3 +1028,30 @@ void ListBox::OnRButtonDown(UINT nFlags, CPoint point)
 {
 CPoint test = point;
 } */
+
+void DisableAllCheats()
+{
+	if(!FCEU_DisableAllCheats() || !hCheat){
+		return;
+	}
+	int selcheattemp = SendDlgItemMessage(hCheat, IDC_LIST_CHEATS, LB_GETCOUNT, 0, 0) - 1;
+	LRESULT sel; char str[259];
+	while(selcheattemp >= 0)
+	{
+		SendDlgItemMessage(hCheat,IDC_LIST_CHEATS,LB_GETTEXT,selcheattemp, (LPARAM)(LPCTSTR)str);
+		if(str[0] == '*')
+		{
+			sel = SendDlgItemMessage(hCheat,IDC_LIST_CHEATS,LB_GETSEL,selcheattemp,0);
+			str[0] = ' ';
+			SendDlgItemMessage(hCheat,IDC_LIST_CHEATS,LB_DELETESTRING,selcheattemp,0);
+			SendDlgItemMessage(hCheat,IDC_LIST_CHEATS,LB_INSERTSTRING,selcheattemp, (LPARAM)(LPSTR)str);
+			if(sel)
+			{
+				SendDlgItemMessage(hCheat,IDC_LIST_CHEATS,LB_SETSEL,1,selcheattemp);
+			}
+		}
+		selcheattemp--;
+	}
+	sprintf(str, "Active Cheats %d", 0);
+	SetDlgItemText(hCheat, 201, str);
+}

--- a/src/drivers/win/cheat.h
+++ b/src/drivers/win/cheat.h
@@ -14,3 +14,5 @@ void UpdateCheatsAdded();
 extern unsigned int FrozenAddressCount;
 extern std::vector<uint16> FrozenAddresses;
 //void ConfigAddCheat(HWND wnd); //bbit edited:commented out this line
+
+void DisableAllCheats();

--- a/src/drivers/win/directories.cpp
+++ b/src/drivers/win/directories.cpp
@@ -143,9 +143,11 @@ static BOOL CALLBACK DirConCallB(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM 
 						"Base Directory",
 					};
 
-					char name[MAX_PATH];
+					char name[MAX_PATH]; 
+					char path[MAX_PATH];
+					GetDlgItemText(hwndDlg, EDIT_ROMS + ((wParam & 0xFFFF) - BUTTON_ROMS), path, MAX_PATH);
 
-					if(BrowseForFolder(hwndDlg, helpert[ ( (wParam & 0xFFFF) - BUTTON_ROMS)], name))
+					if(BrowseForFolder(hwndDlg, helpert[ ( (wParam & 0xFFFF) - BUTTON_ROMS)], name, path))
 					{
 						SetDlgItemText(hwndDlg, EDIT_ROMS + ((wParam & 0xFFFF) - BUTTON_ROMS), name);
 					}

--- a/src/drivers/win/gui.h
+++ b/src/drivers/win/gui.h
@@ -1,4 +1,4 @@
 void ShowCursorAbs(int set_visible);
-int BrowseForFolder(HWND hParent, const char *htext, char *buf);
+int BrowseForFolder(HWND hParent, const char *htext, char *buf, char* defPath = NULL);
 void CenterWindow(HWND hwndDlg);
 void CenterWindowOnScreen(HWND hwnd);

--- a/src/drivers/win/input.cpp
+++ b/src/drivers/win/input.cpp
@@ -1202,6 +1202,9 @@ static void UpdateFourscoreState(HWND dlg)
 		SetDlgItemText(dlg,TXT_PAD1,ESI_Name(SI_GAMEPAD));
 		SetDlgItemText(dlg,TXT_PAD2,ESI_Name(SI_GAMEPAD));
 	}
+
+	EnableWindow(GetDlgItem(dlg,102), enable);
+	EnableWindow(GetDlgItem(dlg,103), enable);
 }
 
 //Callback function of the input configuration dialog.
@@ -1302,7 +1305,7 @@ BOOL CALLBACK InputConCallB(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lPara
 		char btext[128];
 		if (autoHoldKey)
 		{
-			if (!GetKeyNameText(autoHoldKey << 16, btext, 128))
+			if (!GetKeyNameText((autoHoldKey & 0x7F) << 16 | (autoHoldKey & 0x80) << 17, btext, 128))
 				sprintf(btext, "KB: %d", autoHoldKey);
 		} else
 		{
@@ -1483,7 +1486,7 @@ BOOL CALLBACK InputConCallB(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lPara
 
 					if(button)
 					{
-						if(!GetKeyNameText(button << 16, btext, 128))
+						if(!GetKeyNameText((button & 0x7F) << 16 | (button & 0x80) << 17, btext, 128))
 						{
 							sprintf(btext, "KB: %d", button);
 						}
@@ -1509,7 +1512,7 @@ BOOL CALLBACK InputConCallB(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lPara
 
 					if(button)
 					{
-						if( !GetKeyNameText(button << 16, btext, sizeof(btext)))
+						if( !GetKeyNameText((button & 0x7F) << 16 | (button & 0x80 << 17), btext, sizeof(btext)))
 						{
 							sprintf(btext, "KB: %d", button);
 						}

--- a/src/drivers/win/log.cpp
+++ b/src/drivers/win/log.cpp
@@ -2,7 +2,7 @@
 #include "common.h"
 #include "tracer.h"
 
-static HWND logwin = 0;
+HWND logwin = 0;
 
 static char *logtext[MAXIMUM_NUMBER_OF_LOGS];
 static int logcount=0;

--- a/src/drivers/win/main.cpp
+++ b/src/drivers/win/main.cpp
@@ -354,16 +354,51 @@ int BlockingCheck()
 				}
 			}
 
-			if(!handled && taseditorWindow.hwndTASEditor && taseditorEnableAcceleratorKeys)
+			if(!handled && taseditorWindow.hwndTASEditor)
 			{
-				if(IsChild(taseditorWindow.hwndTASEditor, msg.hwnd))
-					handled = TranslateAccelerator(taseditorWindow.hwndTASEditor, fceu_hAccel, &msg);
+				if(taseditorEnableAcceleratorKeys)
+					if(IsChild(taseditorWindow.hwndTASEditor, msg.hwnd))
+						handled = TranslateAccelerator(taseditorWindow.hwndTASEditor, fceu_hAccel, &msg);
+				if(!handled && taseditorWindow.hwndTASEditor){
+					handled = IsDialogMessage(taseditorWindow.hwndTASEditor, &msg);
+				}
 			}
 			if(!handled && taseditorWindow.hwndFindNote)
 			{
 				if(IsChild(taseditorWindow.hwndFindNote, msg.hwnd))
 					handled = IsDialogMessage(taseditorWindow.hwndFindNote, &msg);
 			}
+
+			extern HWND uug;
+			if(!handled && uug && IsChild(uug, msg.hwnd))
+				handled = IsDialogMessage(uug, &msg);
+			if(!handled && pwindow && IsChild(pwindow, msg.hwnd))
+				handled = IsDialogMessage(pwindow, &msg);
+			if(!handled && hCDLogger && IsChild(hCDLogger, msg.hwnd))
+				handled = IsDialogMessage(hCDLogger, &msg);
+			if(!handled && hTracer && IsChild(hTracer, msg.hwnd))
+				handled = IsDialogMessage(hTracer, &msg);
+			extern HWND hGGConv;
+			if(!handled && hGGConv && IsChild(hGGConv, msg.hwnd))
+				handled = IsDialogMessage(hGGConv, &msg);
+			if(!handled && hDebug && IsChild(hDebug, msg.hwnd))
+				handled = IsDialogMessage(hDebug, &msg);
+			extern HWND hPPUView;
+			if(!handled && hPPUView && IsChild(hPPUView, msg.hwnd))
+				handled = IsDialogMessage(hPPUView, &msg);
+			extern HWND hNTView;
+			if(!handled && hNTView && IsChild(hNTView, msg.hwnd))
+				handled = IsDialogMessage(hNTView, &msg);
+			extern HWND hTextHooker;
+			if(!handled && hTextHooker && IsChild(hTextHooker, msg.hwnd))
+				handled = IsDialogMessage(hTextHooker, &msg);
+			extern HWND LuaConsoleHWnd;
+			if(!handled && LuaConsoleHWnd && IsChild(LuaConsoleHWnd, msg.hwnd))
+				handled = IsDialogMessage(LuaConsoleHWnd, &msg);
+			extern HWND logwin;
+			if(!handled && logwin && IsChild(logwin, msg.hwnd))
+				handled = IsDialogMessage(logwin, &msg);
+
 			/* //adelikat - Currently no accel keys are used in the main window.  Uncomment this block to activate them.
 			if(!handled)
 				if(msg.hwnd == hAppWnd)
@@ -711,8 +746,6 @@ int main(int argc,char *argv[])
 		fullscreen=0;
 	}
 
-	CreateMainWindow();
-
 	// Do single instance coding, since we now know if the user wants it,
 	// and we have a source window to send from
 	// http://wiki.github.com/ffi/ffi/windows-examples
@@ -741,11 +774,16 @@ int main(int argc,char *argv[])
 			{
 				//kill this one, activate the other one
 				SetActiveWindow(DoInstantiatedExitWindow);
+				if(IsIconic(DoInstantiatedExitWindow))
+					ShowWindow(DoInstantiatedExitWindow, SW_RESTORE); 
+				SetForegroundWindow(DoInstantiatedExitWindow);
 				do_exit();
 				return 0;
 			}
 		}
 	}
+
+	CreateMainWindow();
 
 	if(!InitDInput())
 	{

--- a/src/drivers/win/mapinput.cpp
+++ b/src/drivers/win/mapinput.cpp
@@ -7,6 +7,7 @@
 #include "../../input.h"
 #include <commctrl.h>
 #include "window.h"
+#include "taseditor/taseditor_window.h"
 
 void KeyboardUpdateState(void); //mbg merge 7/17/06 yech had to add this
 
@@ -689,7 +690,11 @@ BOOL CALLBACK MapInputDialogProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM 
 			PopulateMappingDisplay(hwndDlg);
 
 			// Autosize last column.
-			SendMessage(hwndListView, LVM_SETCOLUMNWIDTH, (WPARAM)2, MAKELPARAM(LVSCW_AUTOSIZE_USEHEADER, 0));
+			SendMessage(hwndListView, LVM_SETCOLUMNWIDTH, (WPARAM)2, MAKELPARAM(LVSCW_AUTOSIZE, 0));
+			SendMessage(hwndListView, LVM_SETCOLUMNWIDTH, (WPARAM)1, MAKELPARAM(LVSCW_AUTOSIZE, 0));
+			RECT rect;
+			GetClientRect(hwndListView, &rect);
+			SendMessage(hwndListView, LVM_SETCOLUMNWIDTH, (WPARAM)2, MAKELPARAM(rect.right - rect.left - SendMessage(hwndListView, LVM_GETCOLUMNWIDTH, 0, 0) - SendMessage(hwndListView, LVM_GETCOLUMNWIDTH, 1, 0), 0));
 
 			CenterWindowOnScreen(hwndDlg);
 		}
@@ -708,6 +713,10 @@ BOOL CALLBACK MapInputDialogProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM 
 		{
 			case IDOK:
 				UpdateMenuHotkeys();
+				// Update TAS Editor's tooltips if it's opening.
+				extern TASEDITOR_WINDOW taseditorWindow;
+				if (taseditorWindow.hwndTASEditor)
+					taseditorWindow.updateTooltips();
 				EndDialog(hwndDlg, 1);
 				return TRUE;
 

--- a/src/drivers/win/memview.cpp
+++ b/src/drivers/win/memview.cpp
@@ -1262,9 +1262,10 @@ LRESULT CALLBACK MemViewCallB(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		// update menus
 		for (i = MODE_NES_MEMORY; i <= MODE_NES_FILE; i++)
-		{
-			CheckMenuItem(GetMenu(hwnd), MENU_MV_VIEW_RAM + i, (EditingMode == i) ? MF_CHECKED : MF_UNCHECKED);
-		}
+			if(EditingMode == i) {
+				CheckMenuRadioItem(GetMenu(hMemView), MENU_MV_VIEW_RAM, MENU_MV_VIEW_ROM, MENU_MV_VIEW_RAM + i, MF_BYCOMMAND);
+				break;
+			}
 		CheckMenuItem(GetMenu(hwnd), ID_HIGHLIGHTING_HIGHLIGHT_ACTIVITY, (MemView_HighlightActivity) ? MF_CHECKED: MF_UNCHECKED);
 		CheckMenuItem(GetMenu(hwnd), ID_HIGHLIGHTING_FADEWHENPAUSED, (MemView_HighlightActivity_FadeWhenPaused) ? MF_CHECKED: MF_UNCHECKED);
 
@@ -2038,9 +2039,11 @@ LRESULT CALLBACK MemViewCallB(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 		case MENU_MV_VIEW_ROM:
 			EditingMode = wParam - MENU_MV_VIEW_RAM;
 			for (i = MODE_NES_MEMORY; i <= MODE_NES_FILE; i++)
-			{
-				CheckMenuItem(GetMenu(hMemView), MENU_MV_VIEW_RAM + i, (EditingMode == i) ? MF_CHECKED : MF_UNCHECKED);
-			}
+				if(EditingMode == i)
+				{
+					CheckMenuRadioItem(GetMenu(hMemView), MENU_MV_VIEW_RAM, MENU_MV_VIEW_ROM, MENU_MV_VIEW_RAM + i, MF_BYCOMMAND);
+					break;
+				}
 			if (EditingMode == MODE_NES_MEMORY)
 				MaxSize = 0x10000;
 			if (EditingMode == MODE_NES_PPU)

--- a/src/drivers/win/memviewsp.cpp
+++ b/src/drivers/win/memviewsp.cpp
@@ -181,7 +181,7 @@ void updateBookmarkMenus(HMENU menu)
 	{
 		// Get the text of the menu
 		char buffer[0x100];
-		sprintf(buffer, i < 10 ? "$%04X - %s\tCTRL-%d" : "$%04X - %s", hexBookmarks[i].address, hexBookmarks[i].description, i);
+		sprintf(buffer, i < 10 ? "&%d. $%04X - %s\tCtrl+%d" : "%d. $%04X - %s",i, hexBookmarks[i].address, hexBookmarks[i].description, i);
 		
 		mi.dwTypeData = buffer;
 		mi.cch = strlen(buffer);

--- a/src/drivers/win/ntview.cpp
+++ b/src/drivers/win/ntview.cpp
@@ -567,6 +567,8 @@ BOOL CALLBACK NTViewCallB(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 							break;
 						case IDC_NTVIEW_SHOW_SCROLL_LINES : 
 							scrolllines ^= 1;
+							EnableWindow(GetDlgItem(hwndDlg, IDC_NTVIEW_SCANLINE_TEXT), scrolllines);
+							EnableWindow(GetDlgItem(hwndDlg, IDC_NTVIEW_SCANLINE), scrolllines);
 							chrchanged = 1;
 							break;
 						case IDC_NTVIEW_SHOW_ATTRIBUTES :

--- a/src/drivers/win/palette.cpp
+++ b/src/drivers/win/palette.cpp
@@ -117,6 +117,11 @@ BOOL CALLBACK PaletteConCallB(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 
 			CenterWindowOnScreen(hwndDlg);
 
+			EnableWindow(GetDlgItem(hwndDlg, 65463), ntsccol_enable);
+			EnableWindow(GetDlgItem(hwndDlg, 64395), ntsccol_enable);
+			EnableWindow(GetDlgItem(hwndDlg, CTL_HUE_TRACKBAR), ntsccol_enable);
+			EnableWindow(GetDlgItem(hwndDlg, CTL_TINT_TRACKBAR), ntsccol_enable);
+
 			break;
 
 		case WM_HSCROLL:
@@ -153,6 +158,11 @@ BOOL CALLBACK PaletteConCallB(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 					case CHECK_PALETTE_ENABLED:
 						ntsccol_enable ^= 1;
 						FCEUI_SetNTSCTH(ntsccol_enable, ntsctint, ntschue); // it recalculates everything, use it for PAL block too!
+						EnableWindow(GetDlgItem(hwndDlg, 65463), ntsccol_enable);
+						EnableWindow(GetDlgItem(hwndDlg, 64395), ntsccol_enable);
+						EnableWindow(GetDlgItem(hwndDlg, CTL_HUE_TRACKBAR), ntsccol_enable);
+						EnableWindow(GetDlgItem(hwndDlg, CTL_TINT_TRACKBAR), ntsccol_enable);
+
 						break;
 
 					case CHECK_PALETTE_GRAYSCALE:

--- a/src/drivers/win/res.rc
+++ b/src/drivers/win/res.rc
@@ -7,93 +7,16 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
-
+#include "afxres.h"
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
 
 /////////////////////////////////////////////////////////////////////////////
-// Russian (Russia) resources
-
-#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_RUS)
-LANGUAGE LANG_RUSSIAN, SUBLANG_DEFAULT
-#pragma code_page(1251)
-
-/////////////////////////////////////////////////////////////////////////////
-//
-// Dialog
-//
-
-IDD_TASEDITOR_SAVINGOPTIONS DIALOGEX 0, 0, 223, 208
-STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "Project file saving options"
-FONT 8, "MS Shell Dlg", 400, 0, 0x1
-BEGIN
-    DEFPUSHBUTTON   "OK",IDOK,109,187,50,14
-    PUSHBUTTON      "Cancel",IDCANCEL,165,187,50,14
-    CONTROL         " Binary format of Input",IDC_CHECK_BINARY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,122,17,89,10
-    CONTROL         " Markers",IDC_CHECK_MARKERS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,122,32,67,10
-    CONTROL         " Bookmarks",IDC_CHECK_BOOKMARKS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,122,47,67,10
-    CONTROL         " History",IDC_CHECK_HISTORY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,122,62,67,10
-    CONTROL         " Piano Roll",IDC_CHECK_PIANO_ROLL,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,122,77,67,10
-    CONTROL         " Selection",IDC_CHECK_SELECTION,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,122,92,67,10
-    GROUPBOX        "File contents",IDC_STATIC,105,4,111,177
-    GROUPBOX        "Greenzone saving options",IDC_STATIC,112,106,97,69
-    CONTROL         " all frames",IDC_RADIO1,"Button",BS_AUTORADIOBUTTON,122,117,77,10
-    CONTROL         " every 16th frame",IDC_RADIO2,"Button",BS_AUTORADIOBUTTON,122,131,77,10
-    CONTROL         " marked frames",IDC_RADIO3,"Button",BS_AUTORADIOBUTTON,122,145,77,10
-    CONTROL         " don't save",IDC_RADIO4,"Button",BS_AUTORADIOBUTTON,122,159,77,10
-    CONTROL         " Autosave project",IDC_AUTOSAVE_PROJECT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,17,81,10
-    CONTROL         " silently",IDC_SILENT_AUTOSAVE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,47,42,10
-    LTEXT           "every",IDC_STATIC,14,32,21,8
-    EDITTEXT        IDC_AUTOSAVE_PERIOD,36,30,24,14,ES_AUTOHSCROLL | ES_NUMBER
-    LTEXT           "minutes",IDC_STATIC,64,32,28,8
-    GROUPBOX        "Settings",IDC_STATIC,6,4,91,177
-END
-
-IDD_SYMBOLIC_DEBUG_NAMING DIALOGEX 0, 0, 245, 83
-STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "Symbolic Debug Naming"
-FONT 8, "MS Shell Dlg", 400, 0, 0x1
-BEGIN
-    DEFPUSHBUTTON   "OK",IDOK,132,62,50,14
-    PUSHBUTTON      "Cancel",IDCANCEL,189,62,50,14
-    LTEXT           "File",IDC_STATIC,7,7,15,9
-    EDITTEXT        IDC_SYMBOLIC_ADDRESS,38,24,33,13,ES_AUTOHSCROLL | ES_READONLY | NOT WS_TABSTOP
-    LTEXT           "Address",IDC_STATIC,6,26,30,10
-    EDITTEXT        IDC_SYMBOLIC_NAME,107,24,132,13,ES_AUTOHSCROLL
-    LTEXT           "Name",IDC_STATIC,83,26,22,10
-    LTEXT           "Comment",IDC_STATIC,6,45,37,10
-    EDITTEXT        IDC_SYMBOLIC_COMMENT,45,43,194,13,ES_AUTOHSCROLL
-    EDITTEXT        IDC_SYMBOLIC_FILENAME,24,6,215,12,ES_AUTOHSCROLL | ES_READONLY | NOT WS_TABSTOP
-END
-
-
-/////////////////////////////////////////////////////////////////////////////
-//
-// DESIGNINFO
-//
-
-#ifdef APSTUDIO_INVOKED
-GUIDELINES DESIGNINFO
-BEGIN
-    IDD_SYMBOLIC_DEBUG_NAMING, DIALOG
-    BEGIN
-        BOTTOMMARGIN, 82
-    END
-END
-#endif    // APSTUDIO_INVOKED
-
-#endif    // Russian (Russia) resources
-/////////////////////////////////////////////////////////////////////////////
-
-
-/////////////////////////////////////////////////////////////////////////////
-// Neutral resources
+// 非特定语言 resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEU)
 LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
-#pragma code_page(1252)
+#pragma code_page(936)
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -431,11 +354,11 @@ BEGIN
     GROUPBOX        "NES Palette",302,10,8,102,81,WS_GROUP
     DEFPUSHBUTTON   "&Load Palette...",BTN_PALETTE_LOAD,18,39,58,14
     CONTROL         "Enabled",CHECK_PALETTE_ENABLED,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,122,22,87,12
-    CONTROL         "Tint",CTL_TINT_TRACKBAR,"msctls_trackbar32",WS_TABSTOP,121,44,91,11
+    CONTROL         "Tint",CTL_TINT_TRACKBAR,"msctls_trackbar32",WS_DISABLED | WS_TABSTOP,121,44,91,11
     GROUPBOX        "NTSC Color Emulation",101,115,8,103,81,WS_GROUP
-    CONTROL         "Hue",CTL_HUE_TRACKBAR,"msctls_trackbar32",WS_TABSTOP,121,69,91,11
-    CTEXT           "Hue",64395,124,59,85,8
-    CTEXT           "Tint",65463,123,34,85,8
+    CONTROL         "Hue",CTL_HUE_TRACKBAR,"msctls_trackbar32",WS_DISABLED | WS_TABSTOP,121,69,91,11
+    CTEXT           "Hue",64395,124,59,85,8,WS_DISABLED
+    CTEXT           "Tint",65463,123,34,85,8,WS_DISABLED
     CONTROL         "Force Grayscale",CHECK_PALETTE_GRAYSCALE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,57,85,12
     CONTROL         "Use Custom Palette",CHECK_PALETTE_CUSTOM,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,22,85,12
     GROUPBOX        "PAL Emulation",IDC_STATIC,10,89,208,66,WS_DISABLED
@@ -513,7 +436,7 @@ BEGIN
     COMBOBOX        COMBO_SOUND_RATE,50,61,53,46,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     LTEXT           "Hz",65460,108,64,15,9
     LTEXT           "Depth:",65462,17,85,27,10
-	COMBOBOX        COMBO_SOUND_8BIT,50,82,67,45,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    COMBOBOX        COMBO_SOUND_8BIT,50,82,67,45,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     CONTROL         "Mute frame advance",CHECK_SOUND_MUTEFA,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,10,110,87,11
     CONTROL         "Mute Turbo",CHECK_SOUND_MUTETURBO,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,138,111,53,10
     GROUPBOX        "Triangle",131,70,142,44,93,WS_GROUP
@@ -654,11 +577,11 @@ BEGIN
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,10,8,183,12
     CONTROL         "Set high-priority thread.",CB_SET_HIGH_PRIORITY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,10,24,102,12
     CONTROL         "Overclocking (old PPU only).",CB_OVERCLOCKING,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,10,41,101,10
-    EDITTEXT        IDC_EXTRA_SCANLINES,104,55,84,14,ES_AUTOHSCROLL
-    LTEXT           "Post-render scanlines:",IDC_STATIC,21,57,74,8
-    CONTROL         "Don't overclock 7-bit samples.",CB_SKIP_7BIT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,10,87,111,10
-    EDITTEXT        IDC_VBLANK_SCANLINES,104,68,84,14,ES_AUTOHSCROLL
-    LTEXT           "VBlank scanlines:",IDC_STATIC,21,71,76,8
+    EDITTEXT        IDC_EXTRA_SCANLINES,104,55,84,14,ES_AUTOHSCROLL | WS_DISABLED
+    LTEXT           "Post-render scanlines:",IDC_EXTRA_SCANLINES_TEXT,21,57,74,8, WS_DISABLED
+    CONTROL         "Don't overclock 7-bit samples.",CB_SKIP_7BIT,"Button",BS_AUTOCHECKBOX | WS_DISABLED | WS_TABSTOP,10,87,111,10
+    EDITTEXT        IDC_VBLANK_SCANLINES,104,68,84,14,ES_AUTOHSCROLL | WS_DISABLED
+    LTEXT           "VBlank scanlines:",IDC_VBLANK_SCANLINES_TEXT,21,71,76,8, WS_DISABLED
 END
 
 MOVIEOPTIONS DIALOGEX 65520, 76, 147, 222
@@ -944,7 +867,7 @@ BEGIN
     LTEXT           "Refresh:   More",-1,225,254,50,9
     CONTROL         "",IDC_NTVIEW_REFRESH_TRACKBAR,"msctls_trackbar32",WS_TABSTOP,275,254,50,11
     LTEXT           "Less",-1,325,254,18,10
-    LTEXT           "Display on scanline:",-1,253,269,65,9
+    LTEXT           "Display on scanline:",IDC_NTVIEW_SCANLINE_TEXT,253,269,65,9
     EDITTEXT        IDC_NTVIEW_SCANLINE,315,267,27,12
     CONTROL         "Show Scroll Lines",IDC_NTVIEW_SHOW_SCROLL_LINES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,254,69,10
     CONTROL         "Show Attributes",IDC_NTVIEW_SHOW_ATTRIBUTES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,265,69,10
@@ -1512,9 +1435,9 @@ BEGIN
     CONTROL         "TV Aspect",IDC_VIDEOCONFIG_TVASPECT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,357,29,48,12
     GROUPBOX        "When resizing the window",65431,188,38,152,43,WS_GROUP
     CONTROL         "Square pixels",IDC_VIDEOCONFIG_SQUARE_PIXELS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,448,14,55,12
-    EDITTEXT        IDC_TVASPECT_X,407,28,41,12,ES_AUTOHSCROLL
-    EDITTEXT        IDC_TVASPECT_Y,458,28,41,12,ES_AUTOHSCROLL
-    CTEXT           "/",IDC_STATIC_SLASHTEXT,449,31,8,8
+    EDITTEXT        IDC_TVASPECT_X,407,28,41,12,ES_AUTOHSCROLL | WS_DISABLED
+    EDITTEXT        IDC_TVASPECT_Y,458,28,41,12,ES_AUTOHSCROLL | WS_DISABLED
+    CTEXT           "/",IDC_STATIC_SLASHTEXT,449,31,8,8,WS_DISABLED
     LTEXT           "DirectDraw:",65454,11,126,46,10
     LTEXT           "DirectDraw:",65455,188,125,46,10
     COMBOBOX        IDC_VIDEOCONFIG_DIRECTDRAW_FS,59,123,105,50,CBS_DROPDOWNLIST | WS_TABSTOP
@@ -1730,6 +1653,10 @@ BEGIN
         BOTTOMMARGIN, 121
     END
 
+    "NTVIEW", DIALOG
+    BEGIN
+    END
+
     "MONITOR", DIALOG
     BEGIN
         LEFTMARGIN, 7
@@ -1754,6 +1681,10 @@ BEGIN
     "IDD_REPLAYINP", DIALOG
     BEGIN
         BOTTOMMARGIN, 198
+    END
+
+    "TASEDITOR", DIALOG
+    BEGIN
     END
 
     "ASSEMBLER", DIALOG
@@ -2460,12 +2391,119 @@ BEGIN
     END
 END
 
-#endif    // Neutral resources
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// AFX_DIALOG_LAYOUT
+//
+
+NTVIEW AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+TIMINGCONFIG AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+#endif    // 非特定语言 resources
 /////////////////////////////////////////////////////////////////////////////
 
 
 /////////////////////////////////////////////////////////////////////////////
-// English (United States) resources
+// 俄语(俄罗斯) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_RUS)
+LANGUAGE LANG_RUSSIAN, SUBLANG_DEFAULT
+#pragma code_page(1251)
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Dialog
+//
+
+IDD_TASEDITOR_SAVINGOPTIONS DIALOGEX 0, 0, 223, 208
+STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "Project file saving options"
+FONT 8, "MS Shell Dlg", 400, 0, 0x1
+BEGIN
+    DEFPUSHBUTTON   "OK",IDOK,109,187,50,14
+    PUSHBUTTON      "Cancel",IDCANCEL,165,187,50,14
+    CONTROL         " Binary format of Input",IDC_CHECK_BINARY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,122,17,89,10
+    CONTROL         " Markers",IDC_CHECK_MARKERS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,122,32,67,10
+    CONTROL         " Bookmarks",IDC_CHECK_BOOKMARKS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,122,47,67,10
+    CONTROL         " History",IDC_CHECK_HISTORY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,122,62,67,10
+    CONTROL         " Piano Roll",IDC_CHECK_PIANO_ROLL,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,122,77,67,10
+    CONTROL         " Selection",IDC_CHECK_SELECTION,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,122,92,67,10
+    GROUPBOX        "File contents",IDC_STATIC,105,4,111,177
+    GROUPBOX        "Greenzone saving options",IDC_STATIC,112,106,97,69
+    CONTROL         " all frames",IDC_RADIO1,"Button",BS_AUTORADIOBUTTON,122,117,77,10
+    CONTROL         " every 16th frame",IDC_RADIO2,"Button",BS_AUTORADIOBUTTON,122,131,77,10
+    CONTROL         " marked frames",IDC_RADIO3,"Button",BS_AUTORADIOBUTTON,122,145,77,10
+    CONTROL         " don't save",IDC_RADIO4,"Button",BS_AUTORADIOBUTTON,122,159,77,10
+    CONTROL         " Autosave project",IDC_AUTOSAVE_PROJECT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,17,81,10
+    CONTROL         " silently",IDC_SILENT_AUTOSAVE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,47,42,10
+    LTEXT           "every",IDC_AUTOSAVE_PERIOD_EVERY_TEXT,14,32,21,8
+    EDITTEXT        IDC_AUTOSAVE_PERIOD,36,30,24,14,ES_AUTOHSCROLL | ES_NUMBER
+    LTEXT           "minutes",IDC_AUTOSAVE_PERIOD_MINUTES_TEXT,64,32,28,8
+    GROUPBOX        "Settings",IDC_STATIC,6,4,91,177
+END
+
+IDD_SYMBOLIC_DEBUG_NAMING DIALOGEX 0, 0, 245, 83
+STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "Symbolic Debug Naming"
+FONT 8, "MS Shell Dlg", 400, 0, 0x1
+BEGIN
+    DEFPUSHBUTTON   "OK",IDOK,132,62,50,14
+    PUSHBUTTON      "Cancel",IDCANCEL,189,62,50,14
+    LTEXT           "File",IDC_STATIC,7,7,15,9
+    EDITTEXT        IDC_SYMBOLIC_ADDRESS,38,24,33,13,ES_AUTOHSCROLL | ES_READONLY | NOT WS_TABSTOP
+    LTEXT           "Address",IDC_STATIC,6,26,30,10
+    EDITTEXT        IDC_SYMBOLIC_NAME,107,24,132,13,ES_AUTOHSCROLL
+    LTEXT           "Name",IDC_STATIC,83,26,22,10
+    LTEXT           "Comment",IDC_STATIC,6,45,37,10
+    EDITTEXT        IDC_SYMBOLIC_COMMENT,45,43,194,13,ES_AUTOHSCROLL
+    EDITTEXT        IDC_SYMBOLIC_FILENAME,24,6,215,12,ES_AUTOHSCROLL | ES_READONLY | NOT WS_TABSTOP
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// DESIGNINFO
+//
+
+#ifdef APSTUDIO_INVOKED
+GUIDELINES DESIGNINFO
+BEGIN
+    IDD_TASEDITOR_SAVINGOPTIONS, DIALOG
+    BEGIN
+    END
+
+    IDD_SYMBOLIC_DEBUG_NAMING, DIALOG
+    BEGIN
+        BOTTOMMARGIN, 82
+    END
+END
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// AFX_DIALOG_LAYOUT
+//
+
+IDD_TASEDITOR_SAVINGOPTIONS AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+#endif    // 俄语(俄罗斯) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+/////////////////////////////////////////////////////////////////////////////
+// 英语(美国) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
@@ -2699,7 +2737,7 @@ IDB_BITMAP_SELECTED17   BITMAP                  "res\\te_17_selected.bmp"
 IDB_BITMAP_SELECTED18   BITMAP                  "res\\te_18_selected.bmp"
 IDB_BITMAP_SELECTED19   BITMAP                  "res\\te_19_selected.bmp"
 IDB_BRANCH_SPRITESHEET  BITMAP                  "res\\branch_spritesheet.bmp"
-#endif    // English (United States) resources
+#endif    // 英语(美国) resources
 /////////////////////////////////////////////////////////////////////////////
 
 
@@ -2709,8 +2747,7 @@ IDB_BRANCH_SPRITESHEET  BITMAP                  "res\\branch_spritesheet.bmp"
 //
 // Generated from the TEXTINCLUDE 3 resource.
 //
-
-
+
 /////////////////////////////////////////////////////////////////////////////
 #endif    // not APSTUDIO_INVOKED
 

--- a/src/drivers/win/resource.h
+++ b/src/drivers/win/resource.h
@@ -1,6 +1,6 @@
 //{{NO_DEPENDENCIES}}
-// Microsoft Visual C++ generated include file.
-// Used by res.rc
+// Microsoft Visual C++ 生成的包含文件。
+// 供 res.rc 使用
 //
 #define CLOSE_BUTTON                    1
 #define BUTTON_CLOSE                    1
@@ -784,6 +784,10 @@
 #define IDC_RICHEDIT_DISASM             1304
 #define IDC_CHECK2                      1305
 #define DEBUGIDAFONT                    1305
+#define IDC_AUTOSAVE_PERIOD_EVERY_TEXT  1306
+#define IDC_AUTOSAVE_PERIOD_MINUTES_TEXT 1307
+#define IDC_VBLANK_SCANLINES_TEXT       1308
+#define IDC_EXTRA_SCANLINES_TEXT        1309
 #define MENU_NETWORK                    40040
 #define MENU_PALETTE                    40041
 #define MENU_SOUND                      40042
@@ -1271,14 +1275,15 @@
 #define IDC_STATIC_SLASHTEXT            65442
 #define IDC_BOOKMARK_NAME_TEXT          65535
 #define ID_CDL                          65535
+#define IDC_NTVIEW_SCANLINE_TEXT        65535
 
 // Next default values for new objects
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        293
+#define _APS_NEXT_RESOURCE_VALUE        296
 #define _APS_NEXT_COMMAND_VALUE         40600
-#define _APS_NEXT_CONTROL_VALUE         1306
+#define _APS_NEXT_CONTROL_VALUE         1310
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/src/drivers/win/sound.cpp
+++ b/src/drivers/win/sound.cpp
@@ -387,7 +387,7 @@ void win_SoundWriteData(int32 *buffer, int count) {
 //--------
 //GUI and control APIs
 
-static HWND uug=0;
+HWND uug=0;
 
 static void UpdateSD(HWND hwndDlg)
 {
@@ -450,6 +450,7 @@ static void UpdateSD(HWND hwndDlg)
 		EnableWindow(GetDlgItem(hwndDlg,65457),FALSE);
 		//Misc. Output Format group
 		EnableWindow(GetDlgItem(hwndDlg,65455),FALSE);
+		EnableWindow(GetDlgItem(hwndDlg,65462),FALSE);
 		EnableWindow(GetDlgItem(hwndDlg,65461),FALSE);
 		EnableWindow(GetDlgItem(hwndDlg,65460),FALSE);
 		
@@ -490,6 +491,7 @@ static void UpdateSD(HWND hwndDlg)
 		EnableWindow(GetDlgItem(hwndDlg,65457),TRUE);
 		//Misc. Output Format group
 		EnableWindow(GetDlgItem(hwndDlg,65455),TRUE);
+		EnableWindow(GetDlgItem(hwndDlg,65462),TRUE);
 		EnableWindow(GetDlgItem(hwndDlg,65461),TRUE);
 		EnableWindow(GetDlgItem(hwndDlg,65460),TRUE);
 		

--- a/src/drivers/win/taseditor.cpp
+++ b/src/drivers/win/taseditor.cpp
@@ -682,12 +682,23 @@ BOOL CALLBACK savingOptionsWndProc(HWND hwndDlg, UINT message, WPARAM wParam, LP
 			CheckDlgButton(hwndDlg, IDC_CHECK_PIANO_ROLL, taseditorConfig.projectSavingOptions_SavePianoRoll?BST_CHECKED : BST_UNCHECKED);
 			CheckDlgButton(hwndDlg, IDC_CHECK_SELECTION, taseditorConfig.projectSavingOptions_SaveSelection?BST_CHECKED : BST_UNCHECKED);
 			CheckRadioButton(hwndDlg, IDC_RADIO1, IDC_RADIO4, IDC_RADIO1 + (taseditorConfig.projectSavingOptions_GreenzoneSavingMode % GREENZONE_SAVING_MODES_TOTAL));
+			EnableWindow(GetDlgItem(hwndDlg, IDC_AUTOSAVE_PERIOD), taseditorConfig.autosaveEnabled);
+			EnableWindow(GetDlgItem(hwndDlg, IDC_AUTOSAVE_PERIOD_EVERY_TEXT), taseditorConfig.autosaveEnabled);
+			EnableWindow(GetDlgItem(hwndDlg, IDC_AUTOSAVE_PERIOD_MINUTES_TEXT), taseditorConfig.autosaveEnabled);
 			return TRUE;
 		}
 		case WM_COMMAND:
 		{
 			switch (LOWORD(wParam))
 			{
+				case IDC_AUTOSAVE_PROJECT:
+				{
+					bool chk = BST_CHECKED == SendDlgItemMessage(hwndDlg, IDC_AUTOSAVE_PROJECT, BM_GETCHECK, 0, 0);
+					EnableWindow(GetDlgItem(hwndDlg, IDC_AUTOSAVE_PERIOD), chk);
+					EnableWindow(GetDlgItem(hwndDlg, IDC_AUTOSAVE_PERIOD_EVERY_TEXT), chk);
+					EnableWindow(GetDlgItem(hwndDlg, IDC_AUTOSAVE_PERIOD_MINUTES_TEXT), chk);
+				}
+					break;
 				case IDOK:
 				{
 					taseditorConfig.autosaveEnabled = (SendDlgItemMessage(hwndDlg, IDC_AUTOSAVE_PROJECT, BM_GETCHECK, 0, 0) == BST_CHECKED);

--- a/src/drivers/win/taseditor/piano_roll.cpp
+++ b/src/drivers/win/taseditor/piano_roll.cpp
@@ -433,7 +433,7 @@ void PIANO_ROLL::reset()
 	mustRedrawList = mustCheckItemUnderMouse = true;
 	playbackCursorOffset = 0;
 	shiftHeld = ctrlHeld = altHeld = false;
-	shiftTimer = ctrlTimer = shiftActions—ount = ctrlActions—ount = 0;
+	shiftTimer = ctrlTimer = shiftActionsCount = ctrlActionsCount = 0;
 	nextHeaderUpdateTime = headerItemUnderMouse = 0;
 	// delete all columns except 0th
 	while (ListView_DeleteColumn(hwndList, 1)) {}
@@ -480,16 +480,16 @@ void PIANO_ROLL::update()
 	{
 		if ((int)(shiftTimer + GetDoubleClickTime()) > clock())
 		{
-			shiftActions—ount++;
-			if (shiftActions—ount >= DOUBLETAP_COUNT)
+			shiftActionsCount++;
+			if (shiftActionsCount >= DOUBLETAP_COUNT)
 			{
 				if (taseditorWindow.TASEditorIsInFocus)
 					followPlaybackCursor();
-				shiftActions—ount = ctrlActions—ount = 0;
+				shiftActionsCount = ctrlActionsCount = 0;
 			}
 		} else
 		{
-			shiftActions—ount = 0;
+			shiftActionsCount = 0;
 		}
 		shiftTimer = clock();
 	}
@@ -497,16 +497,16 @@ void PIANO_ROLL::update()
 	{
 		if ((int)(ctrlTimer + GetDoubleClickTime()) > clock())
 		{
-			ctrlActions—ount++;
-			if (ctrlActions—ount >= DOUBLETAP_COUNT)
+			ctrlActionsCount++;
+			if (ctrlActionsCount >= DOUBLETAP_COUNT)
 			{
 				if (taseditorWindow.TASEditorIsInFocus)
 					followSelection();
-				ctrlActions—ount = shiftActions—ount = 0;
+				ctrlActionsCount = shiftActionsCount = 0;
 			}
 		} else
 		{
-			ctrlActions—ount = 0;
+			ctrlActionsCount = 0;
 		}
 		ctrlTimer = clock();
 	}

--- a/src/drivers/win/taseditor/piano_roll.h
+++ b/src/drivers/win/taseditor/piano_roll.h
@@ -217,7 +217,7 @@ public:
 
 	bool shiftHeld, ctrlHeld, altHeld;
 	int shiftTimer, ctrlTimer;
-	int shiftActions—ount, ctrlActions—ount;
+	int shiftActionsCount, ctrlActionsCount;
 
 	HWND hwndMarkerDragBox, hwndMarkerDragBoxText;
 	// GDI stuff

--- a/src/drivers/win/taseditor/taseditor_window.cpp
+++ b/src/drivers/win/taseditor/taseditor_window.cpp
@@ -132,47 +132,47 @@ char taseditorHelpFilename[] = "\\taseditor.chm";
 // "y < 0" means that the coordinate is counted from the lower border of the window (bottom-aligned)
 // The items in this array MUST be sorted by the same order as the Window_items_enum!
 WindowItemData windowItems[TASEDITOR_WINDOW_TOTAL_ITEMS] = {
-	WINDOWITEMS_PIANO_ROLL, IDC_LIST1, 0, 0, -1, -1, "", "", false, 0, 0,
-	WINDOWITEMS_PLAYBACK_MARKER, IDC_PLAYBACK_MARKER, 0, 0, 0, 0, "Click here to scroll Piano Roll to Playback cursor (hotkey: tap Shift twice)", "", false, 0, 0,
-	WINDOWITEMS_PLAYBACK_MARKER_EDIT, IDC_PLAYBACK_MARKER_EDIT, 0, 0, -1, 0, "Click to edit text", "", false, 0, 0,
-	WINDOWITEMS_SELECTION_MARKER, IDC_SELECTION_MARKER, 0, -1, 0, -1, "Click here to scroll Piano Roll to Selection (hotkey: tap Ctrl twice)", "", false, 0, 0,
-	WINDOWITEMS_SELECTION_MARKER_EDIT, IDC_SELECTION_MARKER_EDIT, 0, -1, -1, -1, "Click to edit text", "", false, 0, 0,
-	WINDOWITEMS_PLAYBACK_BOX, IDC_PLAYBACK_BOX, -1, 0, 0, 0, "", "", false, 0, 0,
-	WINDOWITEMS_PROGRESS_BUTTON, IDC_PROGRESS_BUTTON, -1, 0, 0, 0, "Click here when you want to abort seeking", "", false, EMUCMD_TASEDITOR_CANCEL_SEEKING, 0,
-	WINDOWITEMS_REWIND_FULL, TASEDITOR_REWIND_FULL, -1, 0, 0, 0, "Send Playback to previous Marker (mouse: Shift+Wheel up) (hotkey: Shift+PageUp)", "", false, 0, 0,
-	WINDOWITEMS_REWIND, TASEDITOR_REWIND, -1, 0, 0, 0, "Rewind 1 frame (mouse: Right button+Wheel up) (hotkey: Shift+Up)", "", false, EMUCMD_TASEDITOR_REWIND, 0,
-	WINDOWITEMS_PAUSE, TASEDITOR_PLAYSTOP, -1, 0, 0, 0, "Pause/Unpause Emulation (mouse: Middle button)", "", false, EMUCMD_PAUSE, 0,
-	WINDOWITEMS_FORWARD, TASEDITOR_FORWARD, -1, 0, 0, 0, "Advance 1 frame (mouse: Right button+Wheel down) (hotkey: Shift+Down)", "", false, EMUCMD_FRAME_ADVANCE, 0,
-	WINDOWITEMS_FORWARD_FULL, TASEDITOR_FORWARD_FULL, -1, 0, 0, 0, "Send Playback to next Marker (mouse: Shift+Wheel down) (hotkey: Shift+PageDown)", "", false, 0, 0,
-	WINDOWITEMS_PROGRESS_BAR, IDC_PROGRESS1, -1, 0, 0, 0, "", "", false, 0, 0,
-	WINDOWITEMS_FOLLOW_CURSOR, CHECK_FOLLOW_CURSOR, -1, 0, 0, 0, "The Piano Roll will follow Playback cursor movements", "", false, 0, 0,
-	WINDOWITEMS_TURBO_SEEK, CHECK_TURBO_SEEK, -1, 0, 0, 0, "Uncheck when you need to watch seeking in slow motion", "", false, 0, 0,
-	WINDOWITEMS_AUTORESTORE_PLAYBACK, CHECK_AUTORESTORE_PLAYBACK, -1, 0, 0, 0, "Whenever you change Input above Playback cursor, the cursor returns to where it was before the change", "", false, EMUCMD_TASEDITOR_SWITCH_AUTORESTORING, 0,
-	WINDOWITEMS_RECORDER_BOX, IDC_RECORDER_BOX, -1, 0, 0, 0, "", "", false, 0, 0,
-	WINDOWITEMS_RECORDING, IDC_RECORDING, -1, 0, 0, 0, "Switch Input Recording on/off", "", false, EMUCMD_MOVIE_READONLY_TOGGLE, 0,
-	WINDOWITEMS_RECORD_ALL, IDC_RADIO_ALL, -1, 0, 0, 0, "Switch off Multitracking", "", false, 0, 0,
-	WINDOWITEMS_RECORD_1P, IDC_RADIO_1P, -1, 0, 0, 0, "Select Joypad 1 as current", "", false, EMUCMD_TASEDITOR_SWITCH_MULTITRACKING, 0,
-	WINDOWITEMS_RECORD_2P, IDC_RADIO_2P, -1, 0, 0, 0, "Select Joypad 2 as current", "", false, EMUCMD_TASEDITOR_SWITCH_MULTITRACKING, 0,
-	WINDOWITEMS_RECORD_3P, IDC_RADIO_3P, -1, 0, 0, 0, "Select Joypad 3 as current", "", false, EMUCMD_TASEDITOR_SWITCH_MULTITRACKING, 0,
-	WINDOWITEMS_RECORD_4P, IDC_RADIO_4P, -1, 0, 0, 0, "Select Joypad 4 as current", "", false, EMUCMD_TASEDITOR_SWITCH_MULTITRACKING, 0,
-	WINDOWITEMS_SUPERIMPOSE, IDC_SUPERIMPOSE, -1, 0, 0, 0, "Allows to superimpose old Input with new buttons, instead of overwriting", "", false, 0, 0,
-	WINDOWITEMS_USE_PATTERN, IDC_USEPATTERN, -1, 0, 0, 0, "Applies current Autofire Pattern to Input recording", "", false, 0, 0,
-	WINDOWITEMS_SPLICER_BOX, IDC_SPLICER_BOX, -1, 0, 0, 0, "", "", false, 0, 0,
-	WINDOWITEMS_SELECTION_TEXT, IDC_TEXT_SELECTION, -1, 0, 0, 0, "Current size of Selection", "", false, 0, 0,
-	WINDOWITEMS_CLIPBOARD_TEXT, IDC_TEXT_CLIPBOARD, -1, 0, 0, 0, "Current size of Input in the Clipboard", "", false, 0, 0,
-	WINDOWITEMS_LUA_BOX, IDC_LUA_BOX, -1, 0, 0, 0, "", "", false, 0, 0,
-	WINDOWITEMS_RUN_MANUAL, TASEDITOR_RUN_MANUAL, -1, 0, 0, 0, "Press the button to execute Lua Manual Function", "", false, EMUCMD_TASEDITOR_RUN_MANUAL_LUA, 0,
-	WINDOWITEMS_RUN_AUTO, IDC_RUN_AUTO, -1, 0, 0, 0, "Enable Lua Auto Function (but first it must be registered by Lua script)", "", false, 0, 0,
-	WINDOWITEMS_BRANCHES_BUTTON, IDC_BRANCHES_BUTTON, -1, 0, 0, 0, "Click here to switch between Bookmarks List and Branches Tree", "", false, 0, 0,
-	WINDOWITEMS_BOOKMARKS_BOX, IDC_BOOKMARKS_BOX, -1, 0, 0, 0, "", "", false, 0, 0,
-	WINDOWITEMS_BOOKMARKS_LIST, IDC_BOOKMARKSLIST, -1, 0, 0, 0, "Right click = set Bookmark, Left click = jump to Bookmark or load Branch", "", false, 0, 0,
-	WINDOWITEMS_BRANCHES_BITMAP, IDC_BRANCHES_BITMAP, -1, 0, 0, 0, "Right click = set Bookmark, single Left click = jump to Bookmark, double Left click = load Branch", "", false, 0, 0,
-	WINDOWITEMS_HISTORY_BOX, IDC_HISTORY_BOX, -1, 0, 0, -1, "", "", false, 0, 0,
-	WINDOWITEMS_HISTORY_LIST, IDC_HISTORYLIST, -1, 0, 0, -1, "Click to revert the project back to that time", "", false, 0, 0,
-	WINDOWITEMS_PREVIOUS_MARKER, TASEDITOR_PREV_MARKER, -1, -1, 0, -1, "Send Selection to previous Marker (mouse: Ctrl+Wheel up) (hotkey: Ctrl+PageUp)", "", false, 0, 0,
-	WINDOWITEMS_SIMILAR, TASEDITOR_FIND_BEST_SIMILAR_MARKER, -1, -1, 0, -1, "Auto-search for Marker Note", "", false, 0, 0,
-	WINDOWITEMS_MORE, TASEDITOR_FIND_NEXT_SIMILAR_MARKER, -1, -1, 0, -1, "Continue Auto-search", "", false, 0, 0,
-	WINDOWITEMS_NEXT_MARKER, TASEDITOR_NEXT_MARKER, -1, -1, 0, -1, "Send Selection to next Marker (mouse: Ctrl+Wheel up) (hotkey: Ctrl+PageDown)", "", false, 0, 0,
+	WINDOWITEMS_PIANO_ROLL, IDC_LIST1, 0, 0, -1, -1, "", false, 0, 0,
+	WINDOWITEMS_PLAYBACK_MARKER, IDC_PLAYBACK_MARKER, 0, 0, 0, 0, "Click here to scroll Piano Roll to Playback cursor (hotkey: tap Shift twice)", false, 0, 0,
+	WINDOWITEMS_PLAYBACK_MARKER_EDIT, IDC_PLAYBACK_MARKER_EDIT, 0, 0, -1, 0, "Click to edit text", false, 0, 0,
+	WINDOWITEMS_SELECTION_MARKER, IDC_SELECTION_MARKER, 0, -1, 0, -1, "Click here to scroll Piano Roll to Selection (hotkey: tap Ctrl twice)", false, 0, 0,
+	WINDOWITEMS_SELECTION_MARKER_EDIT, IDC_SELECTION_MARKER_EDIT, 0, -1, -1, -1, "Click to edit text", false, 0, 0,
+	WINDOWITEMS_PLAYBACK_BOX, IDC_PLAYBACK_BOX, -1, 0, 0, 0, "", false, 0, 0,
+	WINDOWITEMS_PROGRESS_BUTTON, IDC_PROGRESS_BUTTON, -1, 0, 0, 0, "Click here when you want to abort seeking", false, EMUCMD_TASEDITOR_CANCEL_SEEKING, 0,
+	WINDOWITEMS_REWIND_FULL, TASEDITOR_REWIND_FULL, -1, 0, 0, 0, "Send Playback to previous Marker (mouse: Shift+Wheel up) (hotkey: Shift+PageUp)", false, 0, 0,
+	WINDOWITEMS_REWIND, TASEDITOR_REWIND, -1, 0, 0, 0, "Rewind 1 frame (mouse: Right button+Wheel up) (hotkey: Shift+Up)", false, EMUCMD_TASEDITOR_REWIND, 0,
+	WINDOWITEMS_PAUSE, TASEDITOR_PLAYSTOP, -1, 0, 0, 0, "Pause/Unpause Emulation (mouse: Middle button)", false, EMUCMD_PAUSE, 0,
+	WINDOWITEMS_FORWARD, TASEDITOR_FORWARD, -1, 0, 0, 0, "Advance 1 frame (mouse: Right button+Wheel down) (hotkey: Shift+Down)", false, EMUCMD_FRAME_ADVANCE, 0,
+	WINDOWITEMS_FORWARD_FULL, TASEDITOR_FORWARD_FULL, -1, 0, 0, 0, "Send Playback to next Marker (mouse: Shift+Wheel down) (hotkey: Shift+PageDown)", false, 0, 0,
+	WINDOWITEMS_PROGRESS_BAR, IDC_PROGRESS1, -1, 0, 0, 0, "", false, 0, 0,
+	WINDOWITEMS_FOLLOW_CURSOR, CHECK_FOLLOW_CURSOR, -1, 0, 0, 0, "The Piano Roll will follow Playback cursor movements", false, 0, 0,
+	WINDOWITEMS_TURBO_SEEK, CHECK_TURBO_SEEK, -1, 0, 0, 0, "Uncheck when you need to watch seeking in slow motion", false, 0, 0,
+	WINDOWITEMS_AUTORESTORE_PLAYBACK, CHECK_AUTORESTORE_PLAYBACK, -1, 0, 0, 0, "Whenever you change Input above Playback cursor, the cursor returns to where it was before the change", false, EMUCMD_TASEDITOR_SWITCH_AUTORESTORING, 0,
+	WINDOWITEMS_RECORDER_BOX, IDC_RECORDER_BOX, -1, 0, 0, 0, "", false, 0, 0,
+	WINDOWITEMS_RECORDING, IDC_RECORDING, -1, 0, 0, 0, "Switch Input Recording on/off", false, EMUCMD_MOVIE_READONLY_TOGGLE, 0,
+	WINDOWITEMS_RECORD_ALL, IDC_RADIO_ALL, -1, 0, 0, 0, "Switch off Multitracking", false, 0, 0,
+	WINDOWITEMS_RECORD_1P, IDC_RADIO_1P, -1, 0, 0, 0, "Select Joypad 1 as current", false, EMUCMD_TASEDITOR_SWITCH_MULTITRACKING, 0,
+	WINDOWITEMS_RECORD_2P, IDC_RADIO_2P, -1, 0, 0, 0, "Select Joypad 2 as current", false, EMUCMD_TASEDITOR_SWITCH_MULTITRACKING, 0,
+	WINDOWITEMS_RECORD_3P, IDC_RADIO_3P, -1, 0, 0, 0, "Select Joypad 3 as current", false, EMUCMD_TASEDITOR_SWITCH_MULTITRACKING, 0,
+	WINDOWITEMS_RECORD_4P, IDC_RADIO_4P, -1, 0, 0, 0, "Select Joypad 4 as current", false, EMUCMD_TASEDITOR_SWITCH_MULTITRACKING, 0,
+	WINDOWITEMS_SUPERIMPOSE, IDC_SUPERIMPOSE, -1, 0, 0, 0, "Allows to superimpose old Input with new buttons, instead of overwriting", false, 0, 0,
+	WINDOWITEMS_USE_PATTERN, IDC_USEPATTERN, -1, 0, 0, 0, "Applies current Autofire Pattern to Input recording", false, 0, 0,
+	WINDOWITEMS_SPLICER_BOX, IDC_SPLICER_BOX, -1, 0, 0, 0, "", false, 0, 0,
+	WINDOWITEMS_SELECTION_TEXT, IDC_TEXT_SELECTION, -1, 0, 0, 0, "Current size of Selection", false, 0, 0,
+	WINDOWITEMS_CLIPBOARD_TEXT, IDC_TEXT_CLIPBOARD, -1, 0, 0, 0, "Current size of Input in the Clipboard", false, 0, 0,
+	WINDOWITEMS_LUA_BOX, IDC_LUA_BOX, -1, 0, 0, 0, "", false, 0, 0,
+	WINDOWITEMS_RUN_MANUAL, TASEDITOR_RUN_MANUAL, -1, 0, 0, 0, "Press the button to execute Lua Manual Function", false, EMUCMD_TASEDITOR_RUN_MANUAL_LUA, 0,
+	WINDOWITEMS_RUN_AUTO, IDC_RUN_AUTO, -1, 0, 0, 0, "Enable Lua Auto Function (but first it must be registered by Lua script)", false, 0, 0,
+	WINDOWITEMS_BRANCHES_BUTTON, IDC_BRANCHES_BUTTON, -1, 0, 0, 0, "Click here to switch between Bookmarks List and Branches Tree", false, 0, 0,
+	WINDOWITEMS_BOOKMARKS_BOX, IDC_BOOKMARKS_BOX, -1, 0, 0, 0, "", false, 0, 0,
+	WINDOWITEMS_BOOKMARKS_LIST, IDC_BOOKMARKSLIST, -1, 0, 0, 0, "Right click = set Bookmark, Left click = jump to Bookmark or load Branch", false, 0, 0,
+	WINDOWITEMS_BRANCHES_BITMAP, IDC_BRANCHES_BITMAP, -1, 0, 0, 0, "Right click = set Bookmark, single Left click = jump to Bookmark, double Left click = load Branch", false, 0, 0,
+	WINDOWITEMS_HISTORY_BOX, IDC_HISTORY_BOX, -1, 0, 0, -1, "", false, 0, 0,
+	WINDOWITEMS_HISTORY_LIST, IDC_HISTORYLIST, -1, 0, 0, -1, "Click to revert the project back to that time", false, 0, 0,
+	WINDOWITEMS_PREVIOUS_MARKER, TASEDITOR_PREV_MARKER, -1, -1, 0, -1, "Send Selection to previous Marker (mouse: Ctrl+Wheel up) (hotkey: Ctrl+PageUp)", false, 0, 0,
+	WINDOWITEMS_SIMILAR, TASEDITOR_FIND_BEST_SIMILAR_MARKER, -1, -1, 0, -1, "Auto-search for Marker Note", false, 0, 0,
+	WINDOWITEMS_MORE, TASEDITOR_FIND_NEXT_SIMILAR_MARKER, -1, -1, 0, -1, "Continue Auto-search", false, 0, 0,
+	WINDOWITEMS_NEXT_MARKER, TASEDITOR_NEXT_MARKER, -1, -1, 0, -1, "Send Selection to next Marker (mouse: Ctrl+Wheel up) (hotkey: Ctrl+PageDown)", false, 0, 0,
 };
 
 TASEDITOR_WINDOW::TASEDITOR_WINDOW()
@@ -184,6 +184,64 @@ TASEDITOR_WINDOW::TASEDITOR_WINDOW()
 	isReadyForResizing = false;
 	minWidth = 0;
 	minHeight = 0;
+}
+
+void TASEDITOR_WINDOW::updateTooltips()
+{
+	for (int i = 0; i < TASEDITOR_WINDOW_TOTAL_ITEMS; ++i)
+	{
+		TOOLINFO toolInfo = { 0 };
+		toolInfo.cbSize = sizeof(TOOLINFO);
+		toolInfo.hwnd = hwndTASEditor;
+		toolInfo.uId = (UINT_PTR)GetDlgItem(hwndTASEditor, windowItems[i].id);
+		if (windowItems[i].isStaticRect)
+		{
+			// for static text we specify rectangle
+			RECT toolRect;
+			GetWindowRect(GetDlgItem(hwndTASEditor, windowItems[i].id), &toolRect);
+			POINT pt;
+			pt.x = toolRect.left;
+			pt.y = toolRect.top;
+			ScreenToClient(hwndTASEditor, &pt);
+			toolInfo.rect.left = pt.x;
+			toolInfo.rect.top = pt.y;
+			toolInfo.rect.right = toolInfo.rect.left + toolRect.right - toolRect.left;
+			toolInfo.rect.bottom = toolInfo.rect.top + toolRect.bottom - toolRect.top;
+			toolInfo.uFlags = TTF_SUBCLASS;
+		}
+		else
+			// for other controls we provide hwnd
+			toolInfo.uFlags = TTF_IDISHWND | TTF_SUBCLASS;
+		char tooltipText[TOOLTIP_TEXT_MAX_LEN];
+		if (windowItems[i].hotkeyEmuCmd && FCEUD_CommandMapping[windowItems[i].hotkeyEmuCmd])
+		{
+			// add hotkey mapping if needed
+			strcpy(tooltipText, windowItems[i].tooltipText);
+			strcat(tooltipText, " (hotkey: ");
+			strcat(tooltipText, GetKeyComboName(FCEUD_CommandMapping[windowItems[i].hotkeyEmuCmd]));
+			strcat(tooltipText, ")");
+			toolInfo.lpszText = tooltipText;
+		} else
+			// No hotkey, use the tooltip text itself
+			toolInfo.lpszText = windowItems[i].tooltipText;
+
+		if(!windowItems[i].tooltipHWND)
+		{
+			// if the tooltip handle is not created yet, create one
+			if (windowItems[i].tooltipHWND = CreateWindowEx(NULL, TOOLTIPS_CLASS, NULL,
+				WS_POPUP | TTS_ALWAYSTIP | TTS_BALLOON | TTS_NOANIMATE | TTS_NOFADE,
+				CW_USEDEFAULT, CW_USEDEFAULT,
+				CW_USEDEFAULT, CW_USEDEFAULT,
+				hwndTASEditor, NULL,
+				fceu_hInstance, NULL))
+			{
+				SendMessage(windowItems[i].tooltipHWND, TTM_ADDTOOL, 0, (LPARAM)&toolInfo);
+				SendMessage(windowItems[i].tooltipHWND, TTM_SETDELAYTIME, TTDT_AUTOPOP, TOOLTIPS_AUTOPOP_TIMEOUT);
+			}
+		} else
+			// The tooltip handle is already created, just update the tooltip info
+			SendMessage(windowItems[i].tooltipHWND, TTM_SETTOOLINFO, 0, (LPARAM)&toolInfo);
+	}
 }
 
 void TASEDITOR_WINDOW::init()
@@ -203,61 +261,8 @@ void TASEDITOR_WINDOW::init()
 	updateCheckedItems();
 	hPatternsMenu = GetSubMenu(hMainMenu, PATTERNS_MENU_POS);
 	// tooltips
-	for (int i = 0; i < TASEDITOR_WINDOW_TOTAL_ITEMS; ++i)
-	{
-		if (windowItems[i].tooltipTextBase[0])
-		{
-			windowItems[i].tooltipHWND = CreateWindowEx(NULL, TOOLTIPS_CLASS, NULL,
-									  WS_POPUP | TTS_ALWAYSTIP | TTS_BALLOON | TTS_NOANIMATE | TTS_NOFADE,
-									  CW_USEDEFAULT, CW_USEDEFAULT,
-									  CW_USEDEFAULT, CW_USEDEFAULT,
-									  hwndTASEditor, NULL, 
-									  fceu_hInstance, NULL);
-			if (windowItems[i].tooltipHWND)
-			{
-				// Associate the tooltip with the tool
-				TOOLINFO toolInfo = {0};
-				toolInfo.cbSize = sizeof(toolInfo);
-				toolInfo.hwnd = hwndTASEditor;
-				toolInfo.uId = (UINT_PTR)GetDlgItem(hwndTASEditor, windowItems[i].id);
-				if (windowItems[i].isStaticRect)
-				{
-					// for static text we specify rectangle
-					toolInfo.uFlags = TTF_SUBCLASS;
-					RECT toolRect;
-					GetWindowRect(GetDlgItem(hwndTASEditor, windowItems[i].id), &toolRect);
-					POINT pt;
-					pt.x = toolRect.left;
-					pt.y = toolRect.top;
-					ScreenToClient(hwndTASEditor, &pt);
-					toolInfo.rect.left = pt.x;
-					toolInfo.rect.right = toolInfo.rect.left + (toolRect.right - toolRect.left);
-					toolInfo.rect.top = pt.y;
-					toolInfo.rect.bottom = toolInfo.rect.top + (toolRect.bottom - toolRect.top);
-				} else
-				{
-					// for other controls we provide hwnd
-					toolInfo.uFlags = TTF_IDISHWND | TTF_SUBCLASS;
-				}
-				// add hotkey mapping if needed
-				if (windowItems[i].hotkeyEmuCmd && FCEUD_CommandMapping[windowItems[i].hotkeyEmuCmd])
-				{
-					windowItems[i].tooltipText[0] = 0;
-					strcpy(windowItems[i].tooltipText, windowItems[i].tooltipTextBase);
-					strcat(windowItems[i].tooltipText, " (hotkey: ");
-					strncat(windowItems[i].tooltipText, GetKeyComboName(FCEUD_CommandMapping[windowItems[i].hotkeyEmuCmd]), TOOLTIP_TEXT_MAX_LEN - strlen(windowItems[i].tooltipText) - 1);
-					strncat(windowItems[i].tooltipText, ")", TOOLTIP_TEXT_MAX_LEN - strlen(windowItems[i].tooltipText) - 1);
-					toolInfo.lpszText = windowItems[i].tooltipText;
-				} else
-				{
-					toolInfo.lpszText = windowItems[i].tooltipTextBase;
-				}
-				SendMessage(windowItems[i].tooltipHWND, TTM_ADDTOOL, 0, (LPARAM)&toolInfo);
-				SendMessage(windowItems[i].tooltipHWND, TTM_SETDELAYTIME, TTDT_AUTOPOP, TOOLTIPS_AUTOPOP_TIMEOUT);
-			}
-		}
-	}
 	updateTooltips();
+	toggleTooltips();
 	// subclass "Marker X" text fields
 	IDC_PLAYBACK_MARKER_oldWndProc = (WNDPROC)SetWindowLong(GetDlgItem(hwndTASEditor, IDC_PLAYBACK_MARKER), GWL_WNDPROC, (LONG)IDC_PLAYBACK_MARKER_WndProc);
 	IDC_SELECTION_MARKER_oldWndProc = (WNDPROC)SetWindowLong(GetDlgItem(hwndTASEditor, IDC_SELECTION_MARKER), GWL_WNDPROC, (LONG)IDC_SELECTION_MARKER_WndProc);
@@ -535,7 +540,7 @@ void TASEDITOR_WINDOW::changeBookmarksListHeight(int newHeight)
 		ShowWindow(hwndTASEditor, SW_SHOWMAXIMIZED);
 }
 
-void TASEDITOR_WINDOW::updateTooltips()
+void TASEDITOR_WINDOW::toggleTooltips()
 {
 	if (taseditorConfig.tooltipsEnabled)
 	{
@@ -1258,7 +1263,7 @@ BOOL CALLBACK TASEditorWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPara
 				case ID_HELP_TOOLTIPS:
 					taseditorConfig.tooltipsEnabled ^= 1;
 					taseditorWindow.updateCheckedItems();
-					taseditorWindow.updateTooltips();
+					taseditorWindow.toggleTooltips();
 					break;
 				case ID_HELP_ABOUT:
 					DialogBox(fceu_hInstance, MAKEINTRESOURCE(IDD_TASEDITOR_ABOUT), taseditorWindow.hwndTASEditor, aboutWndProc);

--- a/src/drivers/win/taseditor/taseditor_window.h
+++ b/src/drivers/win/taseditor/taseditor_window.h
@@ -62,8 +62,8 @@ struct WindowItemData
 	int y;
 	int width;
 	int height;
-	char tooltipTextBase[TOOLTIP_TEXT_MAX_LEN];
-	char tooltipText[TOOLTIP_TEXT_MAX_LEN];
+//	char* tooltipTextBase;
+	char* tooltipText;
 	bool isStaticRect;
 	int hotkeyEmuCmd;
 	HWND tooltipHWND;
@@ -83,6 +83,7 @@ public:
 	void handleWindowMovingOrResizing();
 	void changeBookmarksListHeight(int newHeight);
 
+	void toggleTooltips();
 	void updateTooltips();
 	void updateCaption();
 	void updateCheckedItems();

--- a/src/drivers/win/texthook.h
+++ b/src/drivers/win/texthook.h
@@ -14,3 +14,5 @@ void UpdateTextHooker();
 void KillTextHooker();
 void DoTextHooker();
 void TextHookerCheck();
+
+extern HWND hTextHooker;

--- a/src/drivers/win/timing.cpp
+++ b/src/drivers/win/timing.cpp
@@ -44,20 +44,23 @@ void CloseTimingDialog(HWND hwndDlg)
 	if (postrenderscanlines < 0)
 	{
 		postrenderscanlines = 0;
-		MessageBox(hwndDlg, "Overclocking is when you speed up your CPU, not slow it down!", "Error", MB_OK);
+		MessageBox(hwndDlg, "Overclocking is when you speed up your CPU, not slow it down!", "Error", MB_OK | MB_ICONERROR);
 		sprintf(str,"%d",postrenderscanlines);
 		SetDlgItemText(hwndDlg,IDC_EXTRA_SCANLINES,str);
+		SetFocus(GetDlgItem(hwndDlg, IDC_EXTRA_SCANLINES));
 	}
 	else if (vblankscanlines < 0)
 	{
 		vblankscanlines = 0;
-		MessageBox(hwndDlg, "Overclocking is when you speed up your CPU, not slow it down!", "Error", MB_OK);
+		MessageBox(hwndDlg, "Overclocking is when you speed up your CPU, not slow it down!", "Error", MB_OK | MB_ICONERROR);
 		sprintf(str,"%d",vblankscanlines);
 		SetDlgItemText(hwndDlg,IDC_VBLANK_SCANLINES,str);
+		SetFocus(GetDlgItem(hwndDlg, IDC_VBLANK_SCANLINES));
 	}
 	else if (overclock_enabled && newppu)
 	{
-		MessageBox(hwndDlg, "Overclocking doesn't work with new PPU!", "Error", MB_OK);
+		MessageBox(hwndDlg, "Overclocking doesn't work with new PPU!", "Error", MB_OK | MB_ICONERROR);
+		SetFocus(GetDlgItem(hwndDlg, CB_OVERCLOCKING));
 	}
 	else
 		EndDialog(hwndDlg, 0);
@@ -85,9 +88,20 @@ BOOL CALLBACK TimingConCallB(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lPar
 				CheckDlgButton(hwndDlg, CB_DISABLE_SPEED_THROTTLING, BST_CHECKED);
 			}
 
-			if(overclock_enabled)
-				CheckDlgButton(hwndDlg, CB_OVERCLOCKING, BST_CHECKED);
+			if(newppu)
+			{
+				EnableWindow(GetDlgItem(hwndDlg, CB_OVERCLOCKING), false);
+			}
 
+			if(overclock_enabled)
+			{
+				CheckDlgButton(hwndDlg, CB_OVERCLOCKING, BST_CHECKED);
+				EnableWindow(GetDlgItem(hwndDlg, IDC_EXTRA_SCANLINES), true);
+				EnableWindow(GetDlgItem(hwndDlg, CB_SKIP_7BIT), true);
+				EnableWindow(GetDlgItem(hwndDlg, IDC_VBLANK_SCANLINES), true);
+				EnableWindow(GetDlgItem(hwndDlg, IDC_VBLANK_SCANLINES_TEXT), true);
+				EnableWindow(GetDlgItem(hwndDlg, IDC_EXTRA_SCANLINES_TEXT), true);
+			}
 			if(skip_7bit_overclocking)
 				CheckDlgButton(hwndDlg, CB_SKIP_7BIT, BST_CHECKED);
 
@@ -117,6 +131,16 @@ BOOL CALLBACK TimingConCallB(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lPar
 				{
 					case 1:
 						CloseTimingDialog(hwndDlg);
+						break;
+					case CB_OVERCLOCKING:
+						bool chk = IsDlgButtonChecked(hwndDlg, CB_OVERCLOCKING) == BST_CHECKED;
+						
+						EnableWindow(GetDlgItem(hwndDlg, IDC_EXTRA_SCANLINES), chk);
+						EnableWindow(GetDlgItem(hwndDlg, CB_SKIP_7BIT), chk);
+						EnableWindow(GetDlgItem(hwndDlg, IDC_VBLANK_SCANLINES), chk);
+						EnableWindow(GetDlgItem(hwndDlg, IDC_VBLANK_SCANLINES_TEXT), chk);
+						EnableWindow(GetDlgItem(hwndDlg, IDC_EXTRA_SCANLINES_TEXT), chk);
+						
 						break;
 				}
 			}

--- a/src/drivers/win/video.cpp
+++ b/src/drivers/win/video.cpp
@@ -1283,6 +1283,11 @@ BOOL CALLBACK VideoConCallB(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lPara
 			strcat(buf, " (double-click anywhere)");
 		}
 		SetDlgItemText(hwndDlg, IDC_VIDEOCONFIG_FS, buf);
+
+		EnableWindow(GetDlgItem(hwndDlg, IDC_TVASPECT_X), eoptions&EO_TVASPECT);
+		EnableWindow(GetDlgItem(hwndDlg, IDC_TVASPECT_Y), eoptions&EO_TVASPECT);
+		EnableWindow(GetDlgItem(hwndDlg, IDC_STATIC_SLASHTEXT), eoptions&EO_TVASPECT);
+
 		break;
 	}
 	case WM_CLOSE:
@@ -1398,6 +1403,11 @@ gornk:
 				fssync=SendDlgItemMessage(hwndDlg,IDC_VIDEOCONFIG_SYNC_METHOD_FS,CB_GETCURSEL,0,(LPARAM)(LPSTR)0);
 				EndDialog(hwndDlg,0);
 				break;
+				case IDC_VIDEOCONFIG_TVASPECT:
+					bool enable = SendDlgItemMessage(hwndDlg, IDC_VIDEOCONFIG_TVASPECT, BM_GETCHECK, 0, 0) == BST_CHECKED;
+					EnableWindow(GetDlgItem(hwndDlg, IDC_TVASPECT_X), enable);
+					EnableWindow(GetDlgItem(hwndDlg, IDC_TVASPECT_Y), enable);
+					EnableWindow(GetDlgItem(hwndDlg, IDC_STATIC_SLASHTEXT), enable);
 		}
 	}
 	return 0;

--- a/src/drivers/win/window.h
+++ b/src/drivers/win/window.h
@@ -54,4 +54,31 @@ inline std::wstring GetDlgItemTextW(HWND hDlg, int nIDDlgItem) {
 	return buf;
 }
 
+enum FCEUMENU_HWND {
+	FCEUMENU_CONTEXT_OFF, // NoGame
+	FCEUMENU_CONTEXT_GAME, // Game+NoMovie
+	FCEUMENU_CONTEXT_PLAYING_READONLY, //Game+Movie+Playing+ReadOnly
+	FCEUMENU_CONTEXT_PLAYING_READWRITE, //Game+Movie+Playing+ReadWrite
+	FCEUMENU_CONTEXT_RECORDING_READONLY, //Game+Movie+Recording+ReadOnly
+	FCEUMENU_CONTEXT_RECORDING_READWRITE, //Game+Movie+Recording+Readwrite
+	FCEUMENU_CONTEXT, // parent menu of all context menus,
+	                  // not recommended to use it since there's duplicate ids in context menus,
+	                  // unless you're quite sure the id is unique in all submenus.
+	FCEUMENU_MAIN, // main fceux menu
+	FCEUMENU_LIMIT
+};
+
+struct HOTKEYMENUINDEX {
+	int menu_id; // menu ID
+	int cmd_id;  // hotkey ID
+	int hmenu_index = FCEUMENU_MAIN; // whitch menu it belongs to, refers to FCEUMENU_HWND
+	int flags = MF_BYCOMMAND; // flags when searching and modifying menu item, usually MF_BYCOMMAND
+	// returns an std::string contains original menu text followed with shortcut keys.
+	std::string getQualifiedMenuText();
+	// this is used when you only want to create a qualified menu text String
+	static std::string getQualifiedMenuText(char* text, int cmdid);
+	int updateMenuText();
+	HOTKEYMENUINDEX(int id, int cmd, int menu = FCEUMENU_MAIN, int _flags = MF_BYCOMMAND) : menu_id(id), cmd_id(cmd), hmenu_index(menu), flags(_flags) {}
+};
+
 #endif

--- a/src/fceu.cpp
+++ b/src/fceu.cpp
@@ -416,10 +416,13 @@ FCEUGI *FCEUI_LoadGameVirtual(const char *name, int OverwriteVidMode, bool silen
 
 	if (!fp)
 	{
-		if (!silent)
-			FCEU_PrintError("Error opening \"%s\"!", name);
+		extern bool archiveManuallyCanceled;
+		// Although !fp, if the operation was canceled from archive select dialog box, don't show the error message;
+		if (!silent && !archiveManuallyCanceled)
+			FCEU_PrintError("´ò¿ª \"%s\" ´íÎó£¡", name);
 		return 0;
-	} else if (fp->archiveFilename != "")
+	}
+	else if (fp->archiveFilename != "")
 	{
 		strcpy(fullname, fp->archiveFilename.c_str());
 		strcat(fullname, "|");


### PR DESCRIPTION
1. When cancel from archive loading dialog, don't show loading error boxes and the current playing game doesn't close.
2. Completely rewrite shortcut key displaying logic, now it is not only shown in main menu, but also in context menu.
3. Fix bugs that TAS Editor tooltips shown shortcut keys were not sync when hotkey was changed.
4. If cheat is activated when loading a movie, confirm to disable them as they could cause playback problems.
5. When switching to new ppu with overclocking enabled, prompt to user that new ppu doesn't support overclocking.
6. When in single instance mode, not only exit the emulator, but also bring the existing window to the front.
7. Other minor details about the UI.
