### PR TITLE
Remove the BUSC tag from datalatch mappers

### DIFF
--- a/src/boards/datalatch.cpp
+++ b/src/boards/datalatch.cpp
@@ -122,7 +122,6 @@ static void Latch_Init(CartInfo *info, void (*proc)(void), uint8 init, uint16 ad
 		
 	}
 	AddExState(&latche, 1, 0, "LATC");
-	AddExState(&bus_conflict, 1, 0, "BUSC");
 }
 
 //------------------ Map 0 ---------------------------


### PR DESCRIPTION
For Issue #46, remove the BUSC tag from savestates for data latch mappers, as the bus conflict status is 'set in stone' and does not change over time.
