### PR TITLE
fixes #60

### DIFF
--- a/src/fceu.cpp
+++ b/src/fceu.cpp
@@ -189,11 +189,13 @@ static void FCEU_CloseGame(void)
 		}
 
 		if (GameInfo->type != GIT_NSF) {
+#ifdef WIN32
 			if (disableAutoLSCheats == 2)
 				FCEU_FlushGameCheats(0, 1);
 			else if (disableAutoLSCheats == 1)
 				AskSaveCheat();
 			else if (disableAutoLSCheats == 0)
+#endif
 				FCEU_FlushGameCheats(0, 0);
 		}
 


### PR DESCRIPTION
Addresses Issue #60 

Commit fb1d489 introduced a block of code to prompt the user about saving cheats. That fails on linux/sdl build. This uses an #ifdef to revert that section to before this commit on non-windows builds