### PR TITLE
extra stack clear for lua library table registration

### DIFF
--- a/src/lua-engine.cpp
+++ b/src/lua-engine.cpp
@@ -6098,6 +6098,7 @@ int FCEU_LoadLuaCode(const char *filename, const char *arg) {
 		luaL_register(L, "joypad", joypadlib);
 		luaL_register(L, "zapper", zapperlib);
 		luaL_register(L, "input", inputlib);
+		lua_settop(L, 0); // clean the stack, because each call to luaL_register leaves a table on top (eventually overflows)
 		luaL_register(L, "savestate", savestatelib);
 		luaL_register(L, "movie", movielib);
 		luaL_register(L, "gui", guilib);
@@ -6106,7 +6107,7 @@ int FCEU_LoadLuaCode(const char *filename, const char *arg) {
 		luaL_register(L, "cdlog", cdloglib);
 		luaL_register(L, "taseditor", taseditorlib);
 		luaL_register(L, "bit", bit_funcs); // LuaBitOp library
-		lua_settop(L, 0);		// clean the stack, because each call to luaL_register leaves a table on top
+		lua_settop(L, 0);
 
 		// register a few utility functions outside of libraries (in the global namespace)
 		lua_register(L, "print", print);


### PR DESCRIPTION
Was testing Lua with debug libraries (LUA_USE_APICHECK) and was getting an assert on an overflowing stack once enough libraries pile up here. Sticking in an extra clean seems to take care of this.