### PR TITLE
Update 15.cpp

### DIFF
--- a/src/boards/15.cpp
+++ b/src/boards/15.cpp
@@ -38,20 +38,20 @@ static void Sync(void) {
 	switch (latchea & 3) {
 	case 0:
 		for (i = 0; i < 4; i++)
-			setprg8(0x8000 + (i << 13), (((latched & 0x7F) << 1) + i) ^ (latched >> 7));
+			setprg8(0x8000 + (i << 13), ((latched & 0x3F) << 1) + i);
 		break;
 	case 2:
 		for (i = 0; i < 4; i++)
-			setprg8(0x8000 + (i << 13), ((latched & 0x7F) << 1) + (latched >> 7));
+			setprg8(0x8000 + (i << 13), ((latched & 0x3F) << 1) + (latched >> 7));
 		break;
 	case 1:
 	case 3:
 		for (i = 0; i < 4; i++) {
 			unsigned int b;
-			b = latched & 0x7F;
+			b = latched & 0x3F;
 			if (i >= 2 && !(latchea & 0x2))
-				b = 0x7F;
-			setprg8(0x8000 + (i << 13), (i & 1) + ((b << 1) ^ (latched >> 7)));
+				b = b | 0x07;
+			setprg8(0x8000 + (i << 13), (i & 1) + (b << 1));
 		}
 		break;
 	}


### PR DESCRIPTION
Changes in accordance to the reverse-engineered mapper schematics:
- changed bank mode 1 mapping CPU $C000-$DFFF from "fixed to last bank" to "B OR 7" to support multiple 128KiB UNROM games in one cart
- latch D.7 bit ignored outside bank mode 2
- fixed latch D.6 bit interpreted as bank number bit

Mapper 15 documentation: http://wiki.nesdev.com/w/index.php/INES_Mapper_015 
I did not compile the project to test those changes. No commercial games rely on changed behavior.