### PR TITLE
Palette mirror fix

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -113,7 +113,7 @@ extern void IncrementInstructionsCounters();
 
 //internal variables that debuggers will want access to
 extern uint8 *vnapage[4],*VPage[8];
-extern uint8 PPU[4],PALRAM[0x20],SPRAM[0x100],VRAMBuffer,PPUGenLatch,XOffset;
+extern uint8 PPU[4],PALRAM[0x20],UPALRAM[3],SPRAM[0x100],VRAMBuffer,PPUGenLatch,XOffset;
 extern uint32 FCEUPPU_PeekAddress();
 extern uint8 READPAL_MOTHEROFALL(uint32 A);
 extern int numWPs;

--- a/src/ppu.cpp
+++ b/src/ppu.cpp
@@ -2198,7 +2198,7 @@ int FCEUX_PPU_Loop(int skip) {
 							{
 								pixel = addr & 0x1F;
 							}
-							pixelcolor = PALRAM[pixel];
+							pixelcolor = READPAL_MOTHEROFALL(pixel);
 						}
 
 						//generate the BG data


### PR DESCRIPTION
Addresses issue #80 

1. memview and ppuview can now see all 4 mirrored palette values. Memview can now correctly read and write to them.

2. new PPU will now correctly use the internal mirrored colours ($3F04, etc.) when rendering is disabled via $2001.

These changes are very minimal and should not affect any emulation behaviour, only visual output.

The real mirroring behaviour was already implemented at the emulation level for read/write, it looks like, but memview/ppuview never had a proper way to see the mirrored values.

I'll leave this up for a few days in case there are any comments.