### PR TITLE
CHR size < 1k allows NES program to corrupt memory

### DIFF
--- a/src/cart.cpp
+++ b/src/cart.cpp
@@ -132,6 +132,11 @@ void SetupCartCHRMapping(int chip, uint8 *p, uint32 size, int ram) {
 	CHRmask4[chip] = (size >> 12) - 1;
 	CHRmask8[chip] = (size >> 13) - 1;
 
+	if (CHRmask1[chip] >= (unsigned int)(-1)) CHRmask1[chip] = 0;
+	if (CHRmask2[chip] >= (unsigned int)(-1)) CHRmask2[chip] = 0;
+	if (CHRmask4[chip] >= (unsigned int)(-1)) CHRmask4[chip] = 0;
+	if (CHRmask8[chip] >= (unsigned int)(-1)) CHRmask8[chip] = 0;
+
 	CHRram[chip] = ram;
 }
 

--- a/src/ines.cpp
+++ b/src/ines.cpp
@@ -1017,6 +1017,7 @@ static int iNES_Init(int num) {
 				{
 					CHRRAMSize = iNESCart.battery_vram_size + iNESCart.vram_size;
 				}
+				if (CHRRAMSize < 1024) return 0; // unsupported size, VPage only goes down to 1k banks, NES program can corrupt memory if used
 				if ((VROM = (uint8*)FCEU_dmalloc(CHRRAMSize)) == NULL) return 0;
 				FCEU_MemoryRand(VROM, CHRRAMSize);
 


### PR DESCRIPTION
to fix #109 

Solves the problem by treating CHR RAM < 1024k as an error and refusing to run.

Unfortunately, returning 0 from iNES_Init causes it to report that the mapper is unspported, rather than giving a helpful error, so it would be better to create a better error if possible.

However, it does fix the ability for an NES ROM program to corrupt memory, which is more serious than this unhelpful error message.