### PR TITLE
64-bit windows style fix for #125

### DIFF
--- a/src/drivers/win/guiconfig.cpp
+++ b/src/drivers/win/guiconfig.cpp
@@ -85,7 +85,7 @@ void CloseGuiDialog(HWND hwndDlg)
 				"  manifestVersion=\"1.0\">\n"
 				"<assemblyIdentity\n"
 				"    name=\"FCEUX\"\n"
-				"    processorArchitecture=\"x86\"\n"
+				"    processorArchitecture=\"*\"\n"
 				"    version=\"1.0.0.0\"\n"
 				"    type=\"win32\"/>\n"
 				"<description>FCEUX</description>\n"

--- a/src/drivers/win/main.cpp
+++ b/src/drivers/win/main.cpp
@@ -112,6 +112,15 @@ extern bool taseditorEnableAcceleratorKeys;
  #define __COMPILER__STRING__ "unknown"
 #endif
 
+// 64-bit build requires manifest to use common controls 6 (style adapts to windows version)
+#pragma comment(linker, \
+    "\"/manifestdependency:type='win32' "\
+    "name='Microsoft.Windows.Common-Controls' "\
+    "version='6.0.0.0' "\
+    "processorArchitecture='*' "\
+    "publicKeyToken='6595b64144ccf1df' "\
+    "language='*'\"")
+
 // External functions
 extern std::string cfgFile;		//Contains the filename of the config file used.
 extern bool turbo;				//Is game in turbo mode?


### PR DESCRIPTION
Adds a manifest pragma so that common controls version 6 will be used, rather than falling back to old version with outdated windows form style.