### PR TITLE
Qt SDL GUI Game Pad Config Updates

### DIFF
--- a/src/driver.h
+++ b/src/driver.h
@@ -142,6 +142,7 @@ void FCEUI_SetRenderedLines(int ntscf, int ntscl, int palf, int pall);
 
 //Sets the base directory(save states, snapshots, etc. are saved in directories below this directory.
 void FCEUI_SetBaseDirectory(std::string const & dir);
+const char *FCEUI_GetBaseDirectory(void);
 
 bool FCEUI_GetUserPaletteAvail(void);
 void FCEUI_SetUserPalette(uint8 *pal, int nEntries);

--- a/src/drivers/Qt/ConsoleWindow.cpp
+++ b/src/drivers/Qt/ConsoleWindow.cpp
@@ -78,6 +78,8 @@ consoleWin_t::~consoleWin_t(void)
 {
 	nes_shm->runEmulator = 0;
 
+	gameTimer->stop(); 
+
    if ( gamePadConfWin != NULL )
    {
       gamePadConfWin->closeWindow();

--- a/src/drivers/Qt/GamePadConf.cpp
+++ b/src/drivers/Qt/GamePadConf.cpp
@@ -16,8 +16,10 @@ GamePadConfDialog_t::GamePadConfDialog_t(QWidget *parent)
 	QHBoxLayout *hbox1, *hbox2, *hbox3, *hbox4;
 	QGridLayout *grid;
 	QCheckBox *efs_chkbox, *udlr_chkbox;
-   QGroupBox *frame;
+   QGroupBox *frame1, *frame2;
 	QLabel *label;
+   QPushButton *newProfileButton;
+   QPushButton *applyProfileButton;
    QPushButton *loadDefaultButton;
    QPushButton *clearAllButton;
    QPushButton *closebutton;
@@ -77,6 +79,21 @@ GamePadConfDialog_t::GamePadConfDialog_t(QWidget *parent)
 	hbox3->addWidget( label );
 	hbox3->addWidget( guidLbl );
 
+   frame1 = new QGroupBox(tr("Mapping Profile:"));
+   grid   = new QGridLayout();
+
+   frame1->setLayout( grid );
+
+	mapSel = new QComboBox();
+   applyProfileButton = new QPushButton( tr("Load") );
+   newProfileButton   = new QPushButton( tr("New") );
+
+	grid->addWidget( mapSel            , 0, 0, Qt::AlignCenter );
+	grid->addWidget( applyProfileButton, 0, 1, Qt::AlignCenter );
+	grid->addWidget( newProfileButton  , 0, 2, Qt::AlignCenter );
+
+   mapSel->addItem( tr("Default"), 0 );
+
 	efs_chkbox  = new QCheckBox( tr("Enable Four Score") );
 	udlr_chkbox = new QCheckBox( tr("Allow Up+Down/Left+Right") );
 
@@ -88,13 +105,12 @@ GamePadConfDialog_t::GamePadConfDialog_t(QWidget *parent)
 	g_config->getOption("SDL.Input.EnableOppositeDirectionals", &opposite_dirs);
 	udlr_chkbox->setChecked( opposite_dirs );
 
-   frame = new QGroupBox(tr("Buttons:"));
-   grid  = new QGridLayout();
+   frame2 = new QGroupBox(tr("Current Active Button Mappings:"));
+   grid   = new QGridLayout();
 
    grid-> setHorizontalSpacing(50);
 
-   //frame->setFrameStyle( QFrame::Box );
-   frame->setLayout( grid );
+   frame2->setLayout( grid );
 
    for (int i=0; i<GAMEPAD_NUM_BUTTONS; i++)
    {
@@ -167,9 +183,10 @@ GamePadConfDialog_t::GamePadConfDialog_t(QWidget *parent)
 	mainLayout->addLayout( hbox1 );
 	mainLayout->addLayout( hbox2 );
 	mainLayout->addLayout( hbox3 );
+	mainLayout->addWidget( frame1 );
 	mainLayout->addWidget( efs_chkbox );
 	mainLayout->addWidget( udlr_chkbox );
-	mainLayout->addWidget( frame );
+	mainLayout->addWidget( frame2 );
 	mainLayout->addLayout( hbox4 );
 
 	setLayout( mainLayout );

--- a/src/drivers/Qt/GamePadConf.cpp
+++ b/src/drivers/Qt/GamePadConf.cpp
@@ -28,6 +28,10 @@ GamePadConfDialog_t::GamePadConfDialog_t(QWidget *parent)
    portNum = 0;
    buttonConfigStatus = 1;
 
+   inputTimer  = new QTimer( this );
+
+   connect( inputTimer, &QTimer::timeout, this, &GamePadConfDialog_t::updatePeriodic );
+
    setWindowTitle( tr("GamePad Config") );
 
 	hbox1 = new QHBoxLayout();
@@ -35,7 +39,7 @@ GamePadConfDialog_t::GamePadConfDialog_t(QWidget *parent)
 	hbox3 = new QHBoxLayout();
 	hbox4 = new QHBoxLayout();
 
-	label = new QLabel(tr("Port:"));
+	label = new QLabel(tr("Console Port:"));
 	portSel = new QComboBox();
 	hbox1->addWidget( label );
 	hbox1->addWidget( portSel );
@@ -105,13 +109,17 @@ GamePadConfDialog_t::GamePadConfDialog_t(QWidget *parent)
 
 	   buttonName     = new QLabel(tr(text));
 	   keyName[i]     = new QLabel();
+	   keyState[i]    = new QLabel( tr("F") );
+	   label          = new QLabel( tr("State:") );
       button[i]      = new GamePadConfigButton_t(i);
       clearButton[i] = new QPushButton( tr("Clear") );
 
       grid->addWidget( buttonName    , i, 0, Qt::AlignCenter );
       grid->addWidget( keyName[i]    , i, 1, Qt::AlignCenter );
-      grid->addWidget( button[i]     , i, 2, Qt::AlignCenter );
-      grid->addWidget( clearButton[i], i, 3, Qt::AlignCenter );
+      grid->addWidget( label         , i, 2, Qt::AlignCenter );
+      grid->addWidget( keyState[i]   , i, 3, Qt::AlignCenter );
+      grid->addWidget( button[i]     , i, 4, Qt::AlignCenter );
+      grid->addWidget( clearButton[i], i, 5, Qt::AlignCenter );
    }
 	updateCntrlrDpy();
 
@@ -166,11 +174,13 @@ GamePadConfDialog_t::GamePadConfDialog_t(QWidget *parent)
 
 	setLayout( mainLayout );
 
+   inputTimer->start( 33 ); // 30hz
 }
 
 //----------------------------------------------------
 GamePadConfDialog_t::~GamePadConfDialog_t(void)
 {
+   inputTimer->stop();
    buttonConfigStatus = 0;
 }
 void GamePadConfDialog_t::keyPressEvent(QKeyEvent *event)
@@ -483,6 +493,26 @@ void GamePadConfDialog_t::loadDefaults(void)
 		GamePad[portNum].loadDefaults();
 	}
 	updateCntrlrDpy();
+}
+//----------------------------------------------------
+void GamePadConfDialog_t::updatePeriodic(void)
+{
+   for (int i=0; i<GAMEPAD_NUM_BUTTONS; i++)
+   {
+      const char *txt, *style;
+      if ( GamePad[portNum].bmap[i].state )
+      {
+         txt = "  T  ";
+         style = "background-color: green; color: white;";
+      }
+      else
+      {
+         txt = "  F  ";
+         style = "background-color: red; color: white;";
+      }
+      keyState[i]->setText( tr(txt) );
+      keyState[i]->setStyleSheet( style );
+   }
 }
 //----------------------------------------------------
 GamePadConfigButton_t::GamePadConfigButton_t(int i)

--- a/src/drivers/Qt/GamePadConf.cpp
+++ b/src/drivers/Qt/GamePadConf.cpp
@@ -2,6 +2,7 @@
 //
 #include "Qt/GamePadConf.h"
 #include "Qt/main.h"
+#include "Qt/dface.h"
 #include "Qt/input.h"
 #include "Qt/config.h"
 #include "Qt/keyscan.h"
@@ -19,6 +20,8 @@ GamePadConfDialog_t::GamePadConfDialog_t(QWidget *parent)
    QPushButton *clearAllButton;
    QPushButton *closebutton;
    QPushButton *clearButton[GAMEPAD_NUM_BUTTONS];
+
+	InitJoysticks();
 
    portNum = 0;
    configNo = 0;

--- a/src/drivers/Qt/GamePadConf.cpp
+++ b/src/drivers/Qt/GamePadConf.cpp
@@ -24,7 +24,6 @@ GamePadConfDialog_t::GamePadConfDialog_t(QWidget *parent)
 	InitJoysticks();
 
    portNum = 0;
-   configNo = 0;
    buttonConfigStatus = 1;
 
    setWindowTitle( tr("GamePad Config") );
@@ -157,14 +156,14 @@ void GamePadConfDialog_t::updateCntrlrDpy(void)
 
 	for (int i=0; i<GAMEPAD_NUM_BUTTONS; i++)
 	{
-		if (GamePadConfig[portNum][i].ButtType[configNo] == BUTTC_KEYBOARD)
+		if (GamePadConfig[portNum][i].ButtType == BUTTC_KEYBOARD)
 		{
 			snprintf( keyNameStr, sizeof (keyNameStr), "%s",
-				  SDL_GetKeyName (GamePadConfig[portNum][i].ButtonNum[configNo]));
+				  SDL_GetKeyName (GamePadConfig[portNum][i].ButtonNum));
 		}
 		else
 		{
-			strcpy( keyNameStr, ButtonName( &GamePadConfig[portNum][i], configNo ) );
+			strcpy( keyNameStr, ButtonName( &GamePadConfig[portNum][i] ) );
 		}
 		keyName[i]->setText( tr(keyNameStr) );
 	}
@@ -210,16 +209,16 @@ void GamePadConfDialog_t::changeButton(int padNo, int x)
 
    snprintf (buf, sizeof(buf)-1, "SDL.Input.GamePad.%d.", padNo);
 	prefix = buf;
-	DWaitButton (NULL, &GamePadConfig[padNo][x], configNo, &buttonConfigStatus );
+	DWaitButton (NULL, &GamePadConfig[padNo][x], &buttonConfigStatus );
 
    g_config->setOption (prefix + GamePadNames[x],
-			     GamePadConfig[padNo][x].ButtonNum[configNo]);
+			     GamePadConfig[padNo][x].ButtonNum);
 
-   if (GamePadConfig[padNo][x].ButtType[configNo] == BUTTC_KEYBOARD)
+   if (GamePadConfig[padNo][x].ButtType == BUTTC_KEYBOARD)
 	{
 		g_config->setOption (prefix + "DeviceType", "Keyboard");
 	}
-	else if (GamePadConfig[padNo][x].ButtType[configNo] == BUTTC_JOYSTICK)
+	else if (GamePadConfig[padNo][x].ButtType == BUTTC_JOYSTICK)
 	{
 		g_config->setOption (prefix + "DeviceType", "Joystick");
 	}
@@ -228,9 +227,9 @@ void GamePadConfDialog_t::changeButton(int padNo, int x)
 		g_config->setOption (prefix + "DeviceType", "Unknown");
 	}
 	g_config->setOption (prefix + "DeviceNum",
-			     GamePadConfig[padNo][x].DeviceNum[configNo]);
+			     GamePadConfig[padNo][x].DeviceNum);
 
-   keyNameStr = ButtonName( &GamePadConfig[padNo][x], configNo );
+   keyNameStr = ButtonName( &GamePadConfig[padNo][x] );
 
    keyName[x]->setText( keyNameStr );
    button[x]->setText("Change");
@@ -245,7 +244,7 @@ void GamePadConfDialog_t::clearButton( int padNo, int x )
    char buf[256];
    std::string prefix;
 
-	GamePadConfig[padNo][x].ButtonNum[configNo] = -1;
+	GamePadConfig[padNo][x].ButtonNum = -1;
 
    keyName[x]->setText("");
 
@@ -253,7 +252,7 @@ void GamePadConfDialog_t::clearButton( int padNo, int x )
 	prefix = buf;
 
    g_config->setOption (prefix + GamePadNames[x],
-			     GamePadConfig[padNo][x].ButtonNum[configNo]);
+			     GamePadConfig[padNo][x].ButtonNum);
 
 }
 //----------------------------------------------------
@@ -396,19 +395,18 @@ void GamePadConfDialog_t::loadDefaults(void)
 
 	for (int x=0; x<GAMEPAD_NUM_BUTTONS; x++)
 	{
-		GamePadConfig[portNum][x].ButtType[configNo]  = BUTTC_KEYBOARD;
-		GamePadConfig[portNum][x].DeviceNum[configNo] = 0;
-		GamePadConfig[portNum][x].ButtonNum[configNo] = DefaultGamePad[portNum][x];
-		GamePadConfig[portNum][x].NumC = 1;
+		GamePadConfig[portNum][x].ButtType  = BUTTC_KEYBOARD;
+		GamePadConfig[portNum][x].DeviceNum = 0;
+		GamePadConfig[portNum][x].ButtonNum = DefaultGamePad[portNum][x];
 
 		g_config->setOption (prefix + GamePadNames[x],
-			     GamePadConfig[portNum][x].ButtonNum[configNo]);
+			     GamePadConfig[portNum][x].ButtonNum);
 
-	   if (GamePadConfig[portNum][x].ButtType[configNo] == BUTTC_KEYBOARD)
+	   if (GamePadConfig[portNum][x].ButtType == BUTTC_KEYBOARD)
 		{
 			g_config->setOption (prefix + "DeviceType", "Keyboard");
 		}
-		else if (GamePadConfig[portNum][x].ButtType[configNo] == BUTTC_JOYSTICK)
+		else if (GamePadConfig[portNum][x].ButtType == BUTTC_JOYSTICK)
 		{
 			g_config->setOption (prefix + "DeviceType", "Joystick");
 		}
@@ -417,7 +415,7 @@ void GamePadConfDialog_t::loadDefaults(void)
 			g_config->setOption (prefix + "DeviceType", "Unknown");
 		}
 		g_config->setOption (prefix + "DeviceNum",
-				     GamePadConfig[portNum][x].DeviceNum[configNo]);
+				     GamePadConfig[portNum][x].DeviceNum);
 	}
 	updateCntrlrDpy();
 }

--- a/src/drivers/Qt/GamePadConf.cpp
+++ b/src/drivers/Qt/GamePadConf.cpp
@@ -201,9 +201,10 @@ GamePadConfDialog_t::GamePadConfDialog_t(QWidget *parent)
    connect(clearButton[8], SIGNAL(clicked()), this, SLOT(clearButton8(void)) );
    connect(clearButton[9], SIGNAL(clicked()), this, SLOT(clearButton9(void)) );
 
-   connect(newProfileButton  , SIGNAL(clicked()), this, SLOT(newProfileCallback(void)) );
-   connect(applyProfileButton, SIGNAL(clicked()), this, SLOT(loadProfileCallback(void)) );
-   connect(saveProfileButton , SIGNAL(clicked()), this, SLOT(saveProfileCallback(void)) );
+   connect(newProfileButton   , SIGNAL(clicked()), this, SLOT(newProfileCallback(void)) );
+   connect(applyProfileButton , SIGNAL(clicked()), this, SLOT(loadProfileCallback(void)) );
+   connect(saveProfileButton  , SIGNAL(clicked()), this, SLOT(saveProfileCallback(void)) );
+   connect(removeProfileButton, SIGNAL(clicked()), this, SLOT(deleteProfileCallback(void)) );
 
    connect(loadDefaultButton, SIGNAL(clicked()), this, SLOT(loadDefaults(void)) );
    connect(clearAllButton   , SIGNAL(clicked()), this, SLOT(clearAllCallback(void)) );
@@ -301,6 +302,9 @@ void GamePadConfDialog_t::loadMapList(void)
       fileName.erase( suffixIdx );
 
       //printf("File: %s \n", fileName.c_str() );
+      //
+
+      if ( fileName.compare("default") == 0 ) continue;
 
       mapSel->addItem( tr(fileName.c_str()), (int)i+1 );
    }
@@ -690,6 +694,29 @@ void GamePadConfDialog_t::saveProfileCallback(void)
    }
    mapMsg->setText( tr(stmp) );
 
+}
+//----------------------------------------------------
+void GamePadConfDialog_t::deleteProfileCallback(void)
+{
+   int ret;
+   std::string mapName;
+   char stmp[256];
+
+   mapName = mapSel->currentText().toStdString();
+
+   ret = GamePad[portNum].deleteMapping( mapName.c_str() );
+
+   if ( ret == 0 )
+   {
+      sprintf( stmp, "Mapping Deleted: %s/%s \n", GamePad[portNum].getGUID(), mapName.c_str() );
+   }
+   else
+   {
+      sprintf( stmp, "Error: Failed to Delete Mapping: %s \n", mapName.c_str() );
+   }
+   mapMsg->setText( tr(stmp) );
+
+   loadMapList();
 }
 //----------------------------------------------------
 void GamePadConfDialog_t::updatePeriodic(void)

--- a/src/drivers/Qt/GamePadConf.h
+++ b/src/drivers/Qt/GamePadConf.h
@@ -44,6 +44,7 @@ class GamePadConfDialog_t : public QDialog
 		QComboBox *mapSel;
 		QComboBox *profSel;
 		QLabel      *guidLbl;
+		QLabel      *mapMsg;
       QLabel      *keyName[GAMEPAD_NUM_BUTTONS];
       QLabel      *keyState[GAMEPAD_NUM_BUTTONS];
       GamePadConfigButton_t *button[GAMEPAD_NUM_BUTTONS];
@@ -58,6 +59,8 @@ class GamePadConfDialog_t : public QDialog
       void closeEvent(QCloseEvent *bar);
 	private:
 		void updateCntrlrDpy(void);
+      void createNewProfile( const char *name );
+      void loadMapList(void);
 
    public slots:
       void closeWindow(void);
@@ -88,6 +91,9 @@ class GamePadConfDialog_t : public QDialog
 		void oppDirEna(int state);
 		void portSelect(int index);
 		void deviceSelect(int index);
+      void newProfileCallback(void);
+      void loadProfileCallback(void);
+      void saveProfileCallback(void);
 		void updatePeriodic(void);
 
 };

--- a/src/drivers/Qt/GamePadConf.h
+++ b/src/drivers/Qt/GamePadConf.h
@@ -86,7 +86,7 @@ class GamePadConfDialog_t : public QDialog
       void clearButton8(void);
       void clearButton9(void);
       void clearAllCallback(void);
-      void loadDefaults(void);
+      //void loadDefaults(void);
 		void ena4score(int state);
 		void oppDirEna(int state);
 		void portSelect(int index);

--- a/src/drivers/Qt/GamePadConf.h
+++ b/src/drivers/Qt/GamePadConf.h
@@ -38,11 +38,13 @@ class GamePadConfDialog_t : public QDialog
 
 	protected:
 		QComboBox *portSel;
+		QComboBox *devSel;
+		QComboBox *profSel;
+		QLabel      *guidLbl;
       QLabel      *keyName[GAMEPAD_NUM_BUTTONS];
       GamePadConfigButton_t *button[GAMEPAD_NUM_BUTTONS];
 
       int  portNum;
-		int  configNo;
       int  buttonConfigStatus;
 
       void changeButton( int port, int button );
@@ -80,6 +82,7 @@ class GamePadConfDialog_t : public QDialog
       void loadDefaults(void);
 		void ena4score(int state);
 		void oppDirEna(int state);
-		void controllerSelect(int index);
+		void portSelect(int index);
+		void deviceSelect(int index);
 
 };

--- a/src/drivers/Qt/GamePadConf.h
+++ b/src/drivers/Qt/GamePadConf.h
@@ -41,6 +41,7 @@ class GamePadConfDialog_t : public QDialog
       QTimer    *inputTimer;
 		QComboBox *portSel;
 		QComboBox *devSel;
+		QComboBox *mapSel;
 		QComboBox *profSel;
 		QLabel      *guidLbl;
       QLabel      *keyName[GAMEPAD_NUM_BUTTONS];

--- a/src/drivers/Qt/GamePadConf.h
+++ b/src/drivers/Qt/GamePadConf.h
@@ -12,6 +12,7 @@
 #include <QPushButton>
 #include <QLabel>
 #include <QFrame>
+#include <QTimer>
 #include <QGroupBox>
 
 #include "Qt/main.h"
@@ -37,11 +38,13 @@ class GamePadConfDialog_t : public QDialog
 		~GamePadConfDialog_t(void);
 
 	protected:
+      QTimer    *inputTimer;
 		QComboBox *portSel;
 		QComboBox *devSel;
 		QComboBox *profSel;
 		QLabel      *guidLbl;
       QLabel      *keyName[GAMEPAD_NUM_BUTTONS];
+      QLabel      *keyState[GAMEPAD_NUM_BUTTONS];
       GamePadConfigButton_t *button[GAMEPAD_NUM_BUTTONS];
 
       int  portNum;
@@ -84,5 +87,6 @@ class GamePadConfDialog_t : public QDialog
 		void oppDirEna(int state);
 		void portSelect(int index);
 		void deviceSelect(int index);
+		void updatePeriodic(void);
 
 };

--- a/src/drivers/Qt/GamePadConf.h
+++ b/src/drivers/Qt/GamePadConf.h
@@ -94,6 +94,7 @@ class GamePadConfDialog_t : public QDialog
       void newProfileCallback(void);
       void loadProfileCallback(void);
       void saveProfileCallback(void);
+      void deleteProfileCallback(void);
 		void updatePeriodic(void);
 
 };

--- a/src/drivers/Qt/GamePadConf.h
+++ b/src/drivers/Qt/GamePadConf.h
@@ -59,8 +59,9 @@ class GamePadConfDialog_t : public QDialog
       void closeEvent(QCloseEvent *bar);
 	private:
 		void updateCntrlrDpy(void);
-      void createNewProfile( const char *name );
-      void loadMapList(void);
+		void createNewProfile( const char *name );
+		void loadMapList(void);
+		void saveConfig(void);
 
    public slots:
       void closeWindow(void);
@@ -86,7 +87,6 @@ class GamePadConfDialog_t : public QDialog
       void clearButton8(void);
       void clearButton9(void);
       void clearAllCallback(void);
-      //void loadDefaults(void);
 		void ena4score(int state);
 		void oppDirEna(int state);
 		void portSelect(int index);

--- a/src/drivers/Qt/config.cpp
+++ b/src/drivers/Qt/config.cpp
@@ -102,20 +102,20 @@ LoadCPalette(const std::string &file)
 static void
 CreateDirs(const std::string &dir)
 {
-	const char *subs[8]={"fcs","snaps","gameinfo","sav","cheats","movies","cfg.d"};
+	const char *subs[9]={"fcs","snaps","gameinfo","sav","cheats","movies","input"};
 	std::string subdir;
 	int x;
 
 #if defined(WIN32) || defined(NEED_MINGW_HACKS)
 	mkdir(dir.c_str());
 	chmod(dir.c_str(), 755);
-	for(x = 0; x < 6; x++) {
+	for(x = 0; x < 7; x++) {
 		subdir = dir + PSS + subs[x];
 		mkdir(subdir.c_str());
 	}
 #else
 	mkdir(dir.c_str(), S_IRWXU);
-	for(x = 0; x < 6; x++) {
+	for(x = 0; x < 7; x++) {
 		subdir = dir + PSS + subs[x];
 		mkdir(subdir.c_str(), S_IRWXU);
 	}

--- a/src/drivers/Qt/config.cpp
+++ b/src/drivers/Qt/config.cpp
@@ -317,10 +317,8 @@ InitConfig()
 		prefix = buf;
 
 		config->addOption(prefix + "DeviceType", DefaultGamePadDevice[i]);
-		config->addOption(prefix + "DeviceNum",  0);
-		for(unsigned int j = 0; j < GAMEPAD_NUM_BUTTONS; j++) {
-			config->addOption(prefix + GamePadNames[j], DefaultGamePad[i][j]);
-		}
+		config->addOption(prefix + "DeviceGUID", "");
+		config->addOption(prefix + "Profile"   , "");
 	}
     
 	// PowerPad 0 - 1

--- a/src/drivers/Qt/config.cpp
+++ b/src/drivers/Qt/config.cpp
@@ -242,7 +242,7 @@ InitConfig()
 	config->addOption("input4", "SDL.Input.3", "Gamepad.3");
 
 	// allow for input configuration
-	config->addOption('i', "inputcfg", "SDL.InputCfg", InputCfg);
+	//config->addOption('i', "inputcfg", "SDL.InputCfg", InputCfg);
     
 	// display input
 	config->addOption("inputdisplay", "SDL.InputDisplay", 0);

--- a/src/drivers/Qt/dface.h
+++ b/src/drivers/Qt/dface.h
@@ -18,6 +18,8 @@ void SilenceSound(int s); /* DOS and SDL */
 
 int InitJoysticks(void);
 int KillJoysticks(void);
+int AddJoystick( int which );
+int RemoveJoystick( int which );
 uint32 *GetJSOr(void);
 
 int InitVideo(FCEUGI *gi);

--- a/src/drivers/Qt/fceuWrapper.cpp
+++ b/src/drivers/Qt/fceuWrapper.cpp
@@ -414,6 +414,7 @@ static void ShowUsage(const char *prog)
 int  fceuWrapperInit( int argc, char *argv[] )
 {
 	int error;
+	std::string s;
 
 	for (int i=0; i<argc; i++)
 	{
@@ -468,15 +469,14 @@ int  fceuWrapperInit( int argc, char *argv[] )
 		g_config->save();
 	}
 
-	std::string s;
 
-	g_config->getOption("SDL.InputCfg", &s);
+	//g_config->getOption("SDL.InputCfg", &s);
 
-	if (s.size() != 0)
-	{
-		InitVideo(GameInfo);
-		InputCfg(s);
-	}
+	//if (s.size() != 0)
+	//{
+	//	InitVideo(GameInfo);
+	//	InputCfg(s);
+	//}
 
 	 // update the input devices
 	UpdateInput(g_config);

--- a/src/drivers/Qt/input.cpp
+++ b/src/drivers/Qt/input.cpp
@@ -1956,6 +1956,8 @@ UpdateInput (Config * config)
 	char buf[64];
 	std::string device, prefix;
 
+	InitJoysticks();
+
 	for (unsigned int i = 0; i < 3; i++)
 	{
 		snprintf (buf, 64, "SDL.Input.%u", i);

--- a/src/drivers/Qt/input.cpp
+++ b/src/drivers/Qt/input.cpp
@@ -1909,9 +1909,9 @@ extern Config *g_config;
 /**
  * Update the button configuration for a device, specified by a text string.
  */
-void InputCfg (const std::string & text)
-{
-
+//void InputCfg (const std::string & text)
+//{
+//
 //	if (noGui)
 //	{
 //		if (text.find ("gamepad") != std::string::npos)
@@ -1947,8 +1947,8 @@ void InputCfg (const std::string & text)
 //	}
 //	else
 //		printf ("Please run \"fceux --nogui\" before using --inputcfg\n");
-
-}
+//
+//}
 
 
 /**

--- a/src/drivers/Qt/input.cpp
+++ b/src/drivers/Qt/input.cpp
@@ -1960,7 +1960,7 @@ void InputCfg (const std::string & text)
 UpdateInput (Config * config)
 {
 	char buf[64];
-	std::string device, prefix;
+	std::string device, prefix, guid, mapping;
 
 	InitJoysticks();
 
@@ -2055,37 +2055,18 @@ UpdateInput (Config * config)
 		snprintf (buf, sizeof(buf)-1, "SDL.Input.GamePad.%u.", i);
 		prefix = buf;
 
-		config->getOption (prefix + "DeviceType", &device);
-		if (device.find ("Keyboard") != std::string::npos)
-		{
-			type = BUTTC_KEYBOARD;
-		}
-		else if (device.find ("Joystick") != std::string::npos)
-		{
-			type = BUTTC_JOYSTICK;
-		}
-		else
-		{
-			type = 0;
-		}
+		config->getOption (prefix + "DeviceType", &device );
+		config->getOption (prefix + "DeviceGUID", &guid   );
+		config->getOption (prefix + "Profile"   , &mapping);
 
-		//FIXME
-		//config->getOption (prefix + "DeviceNum", &devnum);
-		//for (unsigned int j = 0; j < GAMEPAD_NUM_BUTTONS; j++)
-		//{
-		//	config->getOption (prefix + GamePadNames[j], &button);
-
-		//	GamePadConfig[i][j].ButtType = type;
-		//	GamePadConfig[i][j].DeviceNum = devnum;
-		//	GamePadConfig[i][j].ButtonNum = button;
-		//}
+		GamePad[i].init( i, guid.c_str(), mapping.c_str() );
 	}
 
 	// PowerPad 0 - 1
 	for (unsigned int i = 0; i < POWERPAD_NUM_DEVICES; i++)
 	{
 		char buf[64];
-		snprintf (buf, 32, "SDL.Input.PowerPad.%u.", i);
+		snprintf (buf, sizeof(buf)-1, "SDL.Input.PowerPad.%u.", i);
 		prefix = buf;
 
 		config->getOption (prefix + "DeviceType", &device);

--- a/src/drivers/Qt/input.cpp
+++ b/src/drivers/Qt/input.cpp
@@ -24,8 +24,9 @@
 #include "Qt/config.h"
 
 
-#include "Qt/sdl-video.h"
 #include "Qt/sdl.h"
+#include "Qt/sdl-video.h"
+#include "Qt/sdl-joystick.h"
 
 #include "common/cheat.h"
 #include "../../movie.h"
@@ -49,8 +50,8 @@ extern bool bindSavestate, frameAdvanceLagSkip, lagCounterDisplay;
 /* UsrInputType[] is user-specified.  CurInputType[] is current
         (game loading can override user settings)
 */
-static int UsrInputType[NUM_INPUT_DEVICES];
-static int CurInputType[NUM_INPUT_DEVICES];
+static int UsrInputType[NUM_INPUT_DEVICES] = { SI_GAMEPAD, SI_GAMEPAD, SI_NONE };
+static int CurInputType[NUM_INPUT_DEVICES] = { SI_GAMEPAD, SI_GAMEPAD, SI_NONE };
 static int cspec = 0;
 static int buttonConfigInProgress = 0;
 
@@ -1007,8 +1008,13 @@ DTestButton (ButtConfig * bc)
 	{
 		if (g_keyState[SDL_GetScancodeFromKey (bc->ButtonNum)])
 		{
+         bc->state = 1;
 			return 1;
 		}
+      else
+      {
+         bc->state = 0;
+      }
 	}
 	else if (bc->ButtType == BUTTC_JOYSTICK)
 	{
@@ -1021,26 +1027,26 @@ DTestButton (ButtConfig * bc)
 }
 
 
-#define MK(x)       {BUTTC_KEYBOARD,0,MKK(x)}
+#define MK(x)       {BUTTC_KEYBOARD,0,MKK(x),0}
 //#define MK2(x1,x2)  {BUTTC_KEYBOARD,0,MKK(x1)}
-#define MKZ()       {0,0,-1}
+#define MKZ()       {0,0,-1,0}
 #define GPZ()       {MKZ(), MKZ(), MKZ(), MKZ()}
 
-ButtConfig GamePadConfig[ GAMEPAD_NUM_DEVICES ][ GAMEPAD_NUM_BUTTONS ] = 
-{
-/* Gamepad 1 */
-	{MK (KP_3), MK (KP_2), MK (SLASH), MK (ENTER),
-	MK (w), MK (z), MK (a), MK (s), MKZ (), MKZ ()},
-
-	/* Gamepad 2 */
-	GPZ (),
-
-	/* Gamepad 3 */
-	GPZ (),
-
-	/* Gamepad 4 */
-	GPZ ()
-};
+//ButtConfig GamePadConfig[ GAMEPAD_NUM_DEVICES ][ GAMEPAD_NUM_BUTTONS ] = 
+//{
+///* Gamepad 1 */
+//	{MK (KP_3), MK (KP_2), MK (SLASH), MK (ENTER),
+//	MK (w), MK (z), MK (a), MK (s), MKZ (), MKZ ()},
+//
+//	/* Gamepad 2 */
+//	GPZ (),
+//
+//	/* Gamepad 3 */
+//	GPZ (),
+//
+//	/* Gamepad 4 */
+//	GPZ ()
+//};
 
 /**
  * Update the status of the gamepad input devices.
@@ -1072,7 +1078,7 @@ UpdateGamepad(void)
 		// a, b, select, start, up, down, left, right
 		for (x = 0; x < 8; x++)
 		{
-			if (DTestButton (&GamePadConfig[wg][x]))
+			if (DTestButton (&GamePad[wg].bmap[x]))
 			{
 				//printf("GamePad%i Button Hit: %i \n", wg, x );
 				if(opposite_dirs == 0)
@@ -1110,7 +1116,7 @@ UpdateGamepad(void)
 		{
 			for (x = 0; x < 2; x++)
 			{
-				if (DTestButton (&GamePadConfig[wg][8 + x]))
+				if (DTestButton (&GamePad[wg].bmap[8 + x]))
 				{
 					JS |= (1 << x) << (wg << 3);
 				}
@@ -2063,15 +2069,16 @@ UpdateInput (Config * config)
 			type = 0;
 		}
 
-		config->getOption (prefix + "DeviceNum", &devnum);
-		for (unsigned int j = 0; j < GAMEPAD_NUM_BUTTONS; j++)
-		{
-			config->getOption (prefix + GamePadNames[j], &button);
+		//FIXME
+		//config->getOption (prefix + "DeviceNum", &devnum);
+		//for (unsigned int j = 0; j < GAMEPAD_NUM_BUTTONS; j++)
+		//{
+		//	config->getOption (prefix + GamePadNames[j], &button);
 
-			GamePadConfig[i][j].ButtType = type;
-			GamePadConfig[i][j].DeviceNum = devnum;
-			GamePadConfig[i][j].ButtonNum = button;
-		}
+		//	GamePadConfig[i][j].ButtType = type;
+		//	GamePadConfig[i][j].DeviceNum = devnum;
+		//	GamePadConfig[i][j].ButtonNum = button;
+		//}
 	}
 
 	// PowerPad 0 - 1

--- a/src/drivers/Qt/input.cpp
+++ b/src/drivers/Qt/input.cpp
@@ -956,6 +956,12 @@ UpdatePhysicalInput ()
 				g_keyState[ event.key.keysym.scancode ] = (event.type == SDL_KEYDOWN) ? 1 : 0;
 				//checkKeyBoardState( event.key.keysym.scancode );
 				break;
+			case SDL_JOYDEVICEADDED:
+				AddJoystick( event.jdevice.which );
+				break;
+			case SDL_JOYDEVICEREMOVED:
+				RemoveJoystick( event.jdevice.which );
+				break;
 			default:
 				break;
 		}
@@ -964,8 +970,6 @@ UpdatePhysicalInput ()
 }
 
 
-static int bcpv=0, bcpj=0;
-
 /**
  *  Begin configuring the buttons by placing the video and joystick
  *  subsystems into a well-known state.  Button configuration really
@@ -973,13 +977,7 @@ static int bcpv=0, bcpj=0;
  */
 int ButtonConfigBegin ()
 {
-	// shut down the joystick subsystems
-	//SDL_Surface *screen;
-
-	bcpj = KillJoysticks ();
-
-	// XXX soules - why did we shut this down?
-	// initialize the joystick subsystem
+	// initialize the joystick subsystem (if not already inited)
 	InitJoysticks ();
 
    buttonConfigInProgress = 1;
@@ -995,18 +993,6 @@ int ButtonConfigBegin ()
 void
 ButtonConfigEnd ()
 {
-	// shutdown the joystick and video subsystems
-	KillJoysticks ();
-	//SDL_QuitSubSystem(SDL_INIT_VIDEO); 
-
-	// re-initialize joystick and video subsystems if they were active before
-	/*if(!bcpv) {
-		InitVideo(GameInfo);
-		} */
-	if (!bcpj)
-	{
-		InitJoysticks ();
-	}
    buttonConfigInProgress = 0;
 }
 

--- a/src/drivers/Qt/input.h
+++ b/src/drivers/Qt/input.h
@@ -17,6 +17,7 @@ struct ButtConfig
 	int    ButtType; //[MAXBUTTCONFIG];
 	int    DeviceNum; //[MAXBUTTCONFIG];
 	int    ButtonNum; //[MAXBUTTCONFIG];
+   int    state;
 	//uint32_t NumC;
 	//uint64 DeviceID[MAXBUTTCONFIG];	/* TODO */
 };

--- a/src/drivers/Qt/input.h
+++ b/src/drivers/Qt/input.h
@@ -59,7 +59,7 @@ int DTestButtonJoy(ButtConfig *bc);
 void FCEUD_UpdateInput(void);
 
 void UpdateInput(Config *config);
-void InputCfg(const std::string &);
+//void InputCfg(const std::string &);
 
 std::string GetUserText(const char* title);
 const char* ButtonName(const ButtConfig* bc);

--- a/src/drivers/Qt/input.h
+++ b/src/drivers/Qt/input.h
@@ -21,7 +21,6 @@ struct ButtConfig
 	//uint64 DeviceID[MAXBUTTCONFIG];	/* TODO */
 };
 
-
 extern int NoWaiting;
 extern CFGSTRUCT InputConfig[];
 extern ARGPSTRUCT InputArgs[];
@@ -46,7 +45,7 @@ void InitInputInterface(void);
 void InputUserActiveFix(void);
 
 extern bool replaceP2StartWithMicrophone;
-extern ButtConfig GamePadConfig[4][10];
+//extern ButtConfig GamePadConfig[4][10];
 //extern ButtConfig powerpadsc[2][12];
 //extern ButtConfig QuizKingButtons[6];
 //extern ButtConfig FTrainerButtons[12];

--- a/src/drivers/Qt/input.h
+++ b/src/drivers/Qt/input.h
@@ -5,7 +5,7 @@
 
 #include "common/configSys.h"
 
-#define MAXBUTTCONFIG   4
+//#define MAXBUTTCONFIG   4
 
 enum {
   BUTTC_KEYBOARD  = 0,
@@ -14,10 +14,10 @@ enum {
 };
 struct ButtConfig
 {
-	int    ButtType[MAXBUTTCONFIG];
-	int    DeviceNum[MAXBUTTCONFIG];
-	int    ButtonNum[MAXBUTTCONFIG];
-	uint32_t NumC;
+	int    ButtType; //[MAXBUTTCONFIG];
+	int    DeviceNum; //[MAXBUTTCONFIG];
+	int    ButtonNum; //[MAXBUTTCONFIG];
+	//uint32_t NumC;
 	//uint64 DeviceID[MAXBUTTCONFIG];	/* TODO */
 };
 
@@ -32,7 +32,7 @@ int getKeyState( int k );
 int ButtonConfigBegin();
 void ButtonConfigEnd();
 void ConfigButton(char *text, ButtConfig *bc);
-int DWaitButton(const uint8_t *text, ButtConfig *bc, int wb, int *buttonConfigStatus = NULL);
+int DWaitButton(const uint8_t *text, ButtConfig *bc, int *buttonConfigStatus = NULL);
 
 
 #define FCFGD_GAMEPAD   1
@@ -62,6 +62,6 @@ void UpdateInput(Config *config);
 void InputCfg(const std::string &);
 
 std::string GetUserText(const char* title);
-const char* ButtonName(const ButtConfig* bc, int which);
+const char* ButtonName(const ButtConfig* bc);
 #endif
 

--- a/src/drivers/Qt/sdl-joystick.cpp
+++ b/src/drivers/Qt/sdl-joystick.cpp
@@ -337,10 +337,17 @@ DTestButtonJoy(ButtConfig *bc)
 	if (bc->ButtonNum & 0x2000)
 	{
 		/* Hat "button" */
-		if(SDL_JoystickGetHat( js,
+		if (SDL_JoystickGetHat( js,
 							((bc->ButtonNum >> 8) & 0x1F)) & 
 							(bc->ButtonNum&0xFF))
+      {
+         bc->state = 1;
 			return 1; 
+      }
+      else
+      {
+         bc->state = 0;
+      }
 	}
 	else if (bc->ButtonNum & 0x8000) 
 	{
@@ -348,16 +355,30 @@ DTestButtonJoy(ButtConfig *bc)
 		int pos;
 		pos = SDL_JoystickGetAxis( js,
 								bc->ButtonNum & 16383);
-		if ((bc->ButtonNum & 0x4000) && pos <= -16383) {
-			return 1;
-		} else if (!(bc->ButtonNum & 0x4000) && pos >= 16363) {
+		if ((bc->ButtonNum & 0x4000) && pos <= -16383) 
+      {
+         bc->state = 1;
 			return 1;
 		}
+      else if (!(bc->ButtonNum & 0x4000) && pos >= 16363) 
+      {
+         bc->state = 1;
+			return 1;
+		}
+      else
+      {
+         bc->state = 0;
+      }
 	} 
-	else if(SDL_JoystickGetButton( js,
+	else if (SDL_JoystickGetButton( js,
 								bc->ButtonNum))
 	{
+      bc->state = 1;
 		return 1;
+   }
+   else
+   {
+      bc->state = 0;
 	}
 
 	return 0;

--- a/src/drivers/Qt/sdl-joystick.cpp
+++ b/src/drivers/Qt/sdl-joystick.cpp
@@ -404,6 +404,10 @@ int GamePad_t::setMapping( nesGamePadMap_t *gpm )
 		bmap[i].DeviceNum = -1;
 		bmap[i].ButtonNum = -1;
 
+		if (gpm->btn[i][0] == 0)
+		{
+			continue;
+		}
       if (gpm->btn[i][0] == 'k')
       {
          SDL_Keycode key;

--- a/src/drivers/Qt/sdl-joystick.cpp
+++ b/src/drivers/Qt/sdl-joystick.cpp
@@ -250,6 +250,7 @@ GamePad_t::GamePad_t(void)
 		bmap[i].ButtType  =  BUTTC_KEYBOARD;
 		bmap[i].DeviceNum = -1;
 		bmap[i].ButtonNum = -1;
+		bmap[i].state     =  0;
 	}
 }
 //********************************************************************************
@@ -661,6 +662,38 @@ int GamePad_t::createProfile( const char *name )
    return 0;
 }
 //********************************************************************************
+int GamePad_t::deleteMapping( const char *name )
+{
+   const char *guid = NULL;
+   const char *baseDir = FCEUI_GetBaseDirectory();
+   std::string path;
+
+   if ( baseDir[0] == 0 )
+   {
+      printf("Error: Invalid base directory\n");
+      return -1;
+   }
+   if ( devIdx >= 0 )
+   {
+      if ( !jsDev[devIdx].isConnected() )
+      {
+         printf("Error: JS%i Not Connected\n", devIdx );
+         return -1;
+      } 
+      guid = jsDev[devIdx].getGUID();
+   }
+   else
+   {
+      guid = "keyboard";
+   }
+   path = std::string(baseDir) + "/input/" + std::string(guid) +
+      "/" + std::string(name) + ".txt";
+
+   //printf("File: '%s'\n", path.c_str() );
+
+   return remove( path.c_str() );
+}
+//********************************************************************************
 jsDev_t *getJoystickDevice( int devNum )
 {
 	if ( (devNum >= 0) && (devNum < MAX_JOYSTICKS) )
@@ -803,7 +836,7 @@ int AddJoystick( int which )
 			}
 			else
 			{
-				printf("Added Joystick: %i \n", which );
+				//printf("Added Joystick: %i \n", which );
 				jsDev[which].init(which);
 				//jsDev[which].print();
 				//printJoystick( s_Joysticks[which] );
@@ -820,7 +853,7 @@ int AddJoystick( int which )
 			}
 			else
 			{
-				printf("Added Joystick: %i \n", which );
+				//printf("Added Joystick: %i \n", which );
 				jsDev[which].init(which);
 				//jsDev[which].print();
 				//printJoystick( s_Joysticks[which] );

--- a/src/drivers/Qt/sdl-joystick.cpp
+++ b/src/drivers/Qt/sdl-joystick.cpp
@@ -120,41 +120,40 @@ static int s_jinited = 0;
 int
 DTestButtonJoy(ButtConfig *bc)
 {
-	int x;
    SDL_Joystick *js;
 
-	for(x = 0; x < bc->NumC; x++)
+	if (bc->ButtonNum == -1)
 	{
-		if (bc->ButtonNum[x] == -1)
-		{
-			continue;
-		}
-		js = jsDev[bc->DeviceNum[x]].getJS();
+		return 0;
+	}
+	js = jsDev[bc->DeviceNum].getJS();
 
-		if (bc->ButtonNum[x] & 0x2000)
-		{
-			/* Hat "button" */
-			if(SDL_JoystickGetHat( js,
-								((bc->ButtonNum[x] >> 8) & 0x1F)) & 
-								(bc->ButtonNum[x]&0xFF))
-				return 1; 
+	if (bc->ButtonNum & 0x2000)
+	{
+		/* Hat "button" */
+		if(SDL_JoystickGetHat( js,
+							((bc->ButtonNum >> 8) & 0x1F)) & 
+							(bc->ButtonNum&0xFF))
+			return 1; 
+	}
+	else if (bc->ButtonNum & 0x8000) 
+	{
+		/* Axis "button" */
+		int pos;
+		pos = SDL_JoystickGetAxis( js,
+								bc->ButtonNum & 16383);
+		if ((bc->ButtonNum & 0x4000) && pos <= -16383) {
+			return 1;
+		} else if (!(bc->ButtonNum & 0x4000) && pos >= 16363) {
+			return 1;
 		}
-		else if (bc->ButtonNum[x] & 0x8000) 
-		{
-			/* Axis "button" */
-			int pos;
-			pos = SDL_JoystickGetAxis( js,
-									bc->ButtonNum[x] & 16383);
-			if ((bc->ButtonNum[x] & 0x4000) && pos <= -16383) {
-				return 1;
-			} else if (!(bc->ButtonNum[x] & 0x4000) && pos >= 16363) {
-				return 1;
-			}
-		} 
-		else if(SDL_JoystickGetButton( js,
-									bc->ButtonNum[x]))
+	} 
+	else if(SDL_JoystickGetButton( js,
+								bc->ButtonNum))
+	{
 		return 1;
 	}
+
 	return 0;
 }
 

--- a/src/drivers/Qt/sdl-joystick.cpp
+++ b/src/drivers/Qt/sdl-joystick.cpp
@@ -30,7 +30,86 @@
 #include <cerrno>
 
 #define MAX_JOYSTICKS	32
-static SDL_Joystick *s_Joysticks[MAX_JOYSTICKS] = {NULL};
+struct jsDev_t
+{
+   SDL_Joystick *js;
+	SDL_GameController *gc;
+
+	jsDev_t(void)
+	{
+   	js = NULL;
+		gc = NULL;
+	};	
+
+	//~jsDev_t(void)
+	//{
+	//	if ( js )
+	//	{
+	//		SDL_JoystickClose( js ); js = NULL;
+	//	}
+	//	if ( gc )
+	//	{
+	//		SDL_GameControllerClose( gc ); gc = NULL;
+	//	}
+	//}
+
+	int close(void)
+	{
+		if ( js )
+		{
+			SDL_JoystickClose( js ); js = NULL;
+		}
+		if ( gc )
+		{
+			SDL_GameControllerClose( gc ); gc = NULL;
+		}
+		return 0;
+	}
+
+	SDL_Joystick *getJS(void)
+	{
+		if ( gc != NULL )
+		{
+			return SDL_GameControllerGetJoystick( gc );
+		}
+		return js;
+	}
+
+	bool isGameController(void)
+	{
+		return ( gc != NULL );
+	}
+
+	bool inUse(void)
+	{
+		return ( (js != NULL) || (gc != NULL) );
+	}
+
+	void print(void)
+	{
+		char guidStr[64];
+
+		SDL_JoystickGUID guid = SDL_JoystickGetGUID( getJS() );
+
+		SDL_JoystickGetGUIDString( guid, guidStr, sizeof(guidStr) );
+
+		printf("JoyStickID: %i: '%s'  \n", 
+			SDL_JoystickInstanceID( getJS() ),	SDL_JoystickName( getJS() ) );
+		printf("GUID: %s \n", guidStr );
+		printf("NumAxes: %i \n", SDL_JoystickNumAxes(getJS()) );
+		printf("NumButtons: %i \n", SDL_JoystickNumButtons(getJS()) );
+		printf("NumHats: %i \n", SDL_JoystickNumHats(getJS()) );
+
+		if ( gc )
+		{
+			printf("GameController Name: '%s'\n", SDL_GameControllerName(gc) );
+			printf("GameController Mapping: %s\n", SDL_GameControllerMapping(gc) );
+		}
+	}
+};
+
+static jsDev_t  jsDev[ MAX_JOYSTICKS ];
+//static SDL_Joystick *s_Joysticks[MAX_JOYSTICKS] = {NULL};
 
 static int s_jinited = 0;
 
@@ -42,6 +121,7 @@ int
 DTestButtonJoy(ButtConfig *bc)
 {
 	int x;
+   SDL_Joystick *js;
 
 	for(x = 0; x < bc->NumC; x++)
 	{
@@ -49,10 +129,12 @@ DTestButtonJoy(ButtConfig *bc)
 		{
 			continue;
 		}
+		js = jsDev[bc->DeviceNum[x]].getJS();
+
 		if (bc->ButtonNum[x] & 0x2000)
 		{
 			/* Hat "button" */
-			if(SDL_JoystickGetHat(s_Joysticks[bc->DeviceNum[x]],
+			if(SDL_JoystickGetHat( js,
 								((bc->ButtonNum[x] >> 8) & 0x1F)) & 
 								(bc->ButtonNum[x]&0xFF))
 				return 1; 
@@ -61,7 +143,7 @@ DTestButtonJoy(ButtConfig *bc)
 		{
 			/* Axis "button" */
 			int pos;
-			pos = SDL_JoystickGetAxis(s_Joysticks[bc->DeviceNum[x]],
+			pos = SDL_JoystickGetAxis( js,
 									bc->ButtonNum[x] & 16383);
 			if ((bc->ButtonNum[x] & 0x4000) && pos <= -16383) {
 				return 1;
@@ -69,57 +151,162 @@ DTestButtonJoy(ButtConfig *bc)
 				return 1;
 			}
 		} 
-		else if(SDL_JoystickGetButton(s_Joysticks[bc->DeviceNum[x]],
+		else if(SDL_JoystickGetButton( js,
 									bc->ButtonNum[x]))
 		return 1;
 	}
 	return 0;
 }
 
+
+//static void printJoystick( SDL_Joystick *js )
+//{
+//	char guidStr[64];
+//   SDL_Joystick *js;
+//
+//	js = jsDev[i].getJS();
+//
+//	SDL_JoystickGUID guid = SDL_JoystickGetGUID( js );
+//
+//	SDL_JoystickGetGUIDString( guid, guidStr, sizeof(guidStr) );
+//
+//	printf("JoyStickID: %i: %s  \n", 
+//		SDL_JoystickInstanceID( js ),	SDL_JoystickName( js ) );
+//	printf("GUID: %s \n", guidStr );
+//	printf("NumAxes: %i \n", SDL_JoystickNumAxes(js) );
+//	printf("NumButtons: %i \n", SDL_JoystickNumButtons(js) );
+//	printf("NumHats: %i \n", SDL_JoystickNumHats(js) );
+//
+//}
+
 /**
  * Shutdown the SDL joystick subsystem.
  */
 int
-KillJoysticks()
+KillJoysticks(void)
 {
 	int n;  /* joystick index */
 
-	if(!s_jinited) {
+	if (!s_jinited) {
 		return -1;
 	}
 
-	for(n = 0; n < MAX_JOYSTICKS; n++) {
-		if (s_Joysticks[n] != 0) {
-			SDL_JoystickClose(s_Joysticks[n]);
-		}
-		s_Joysticks[n]=0;
+	for (n = 0; n < MAX_JOYSTICKS; n++) 
+	{
+		jsDev[n].close();
 	}
 	SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
 	return 0;
+}
+
+int AddJoystick( int which )
+{
+	if ( jsDev[ which ].inUse() )
+	{
+		//printf("Error: Joystick already exists at device index %i \n", which );
+		return -1;
+	}
+	else
+	{
+		if ( SDL_IsGameController(which) )
+		{
+			jsDev[which].gc = SDL_GameControllerOpen(which);
+
+			if ( jsDev[which].gc == NULL )
+			{
+				printf("Could not open game controller %d: %s.\n",
+					which, SDL_GetError());
+			}
+			else
+			{
+				printf("Added Joystick: %i \n", which );
+				jsDev[which].print();
+				//printJoystick( s_Joysticks[which] );
+			}
+		}
+		else
+		{
+			jsDev[which].js = SDL_JoystickOpen(which);
+
+			if ( jsDev[which].js == NULL )
+			{
+				printf("Could not open joystick %d: %s.\n",
+					which, SDL_GetError());
+			}
+			else
+			{
+				printf("Added Joystick: %i \n", which );
+				jsDev[which].print();
+				//printJoystick( s_Joysticks[which] );
+			}
+		}
+	}
+	return 0;
+}
+
+int RemoveJoystick( int which )
+{
+	//printf("Remove Joystick: %i \n", which );
+
+	for (int i=0; i<MAX_JOYSTICKS; i++)
+	{
+		if ( jsDev[i].inUse() )
+		{
+			if ( SDL_JoystickInstanceID( jsDev[i].getJS() ) == which )
+			{
+				printf("Remove Joystick: %i \n", which );
+				jsDev[i].close();
+				return 0;
+			}
+		}
+	}
+	return -1;
 }
 
 /**
  * Initialize the SDL joystick subsystem.
  */
 int
-InitJoysticks()
+InitJoysticks(void)
 {
 	int n; /* joystick index */
 	int total;
 
+	if (s_jinited) {
+		return 1;
+	}
 	SDL_InitSubSystem(SDL_INIT_JOYSTICK);
 
 	total = SDL_NumJoysticks();
-	if(total>MAX_JOYSTICKS) {
+	if (total > MAX_JOYSTICKS) 
+	{
 		total = MAX_JOYSTICKS;
 	}
 
-	for(n = 0; n < total; n++) {
+	for (n = 0; n < total; n++) 
+	{
 		/* Open the joystick under SDL. */
-		s_Joysticks[n] = SDL_JoystickOpen(n);
-		//printf("Could not open joystick %d: %s.\n",
-		//joy[n] - 1, SDL_GetError());
-		continue;
+		AddJoystick(n);
+		//if ( SDL_IsGameController(n) )
+		//{
+		//	SDL_GameController *gc = SDL_GameControllerOpen(n);
+		//	printf("Is Game Controller: %i \n", n);
+
+		//	printf("Mapping: %s \n", SDL_GameControllerMapping(gc) );
+		//}
+		//	s_Joysticks[n] = SDL_JoystickOpen(n);
+
+		//if ( s_Joysticks[n] == NULL )
+		//{
+		//	printf("Could not open joystick %d: %s.\n",
+		//		n, SDL_GetError());
+		//}
+		//else
+		//{
+		//	printf("Opened JS %i: \n", SDL_JoystickInstanceID( s_Joysticks[n] ) );
+		//	jsDev[which].print();
+		//	//printJoystick( s_Joysticks[n] );
+		//}
 	}
 
 	s_jinited = 1;

--- a/src/drivers/Qt/sdl-joystick.cpp
+++ b/src/drivers/Qt/sdl-joystick.cpp
@@ -484,6 +484,18 @@ int GamePad_t::getDefaultMap( char *out, const char *guid )
          return 0;
 	   }
 	}
+	else
+	{
+		if ( strcmp( guid, "keyboard" ) == 0 )
+		{
+			for (int x=0; x<GAMEPAD_NUM_BUTTONS; x++)
+			{
+				bmap[x].ButtType  = BUTTC_KEYBOARD;
+				bmap[x].DeviceNum = 0;
+				bmap[x].ButtonNum = DefaultGamePad[0][x];
+			}
+		}
+	}
    return -1;
 }
 //********************************************************************************

--- a/src/drivers/Qt/sdl-joystick.cpp
+++ b/src/drivers/Qt/sdl-joystick.cpp
@@ -932,6 +932,9 @@ KillJoysticks(void)
 		jsDev[n].close();
 	}
 	SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
+
+	s_jinited = 0;
+
 	return 0;
 }
 

--- a/src/drivers/Qt/sdl-joystick.h
+++ b/src/drivers/Qt/sdl-joystick.h
@@ -15,8 +15,13 @@ struct nesGamePadMap_t
 {
    char guid[64];
    char name[128];
-   char btn[GAMEPAD_NUM_BUTTONS];
+   char btn[GAMEPAD_NUM_BUTTONS][32];
    char os[64];
+
+   nesGamePadMap_t(void);
+  ~nesGamePadMap_t(void);
+
+   int parseMapping( const char *text );
 };
 
 struct jsDev_t
@@ -57,6 +62,7 @@ class GamePad_t
 	int  loadDefaults(void);
 
 	int  setMapping( const char *map );
+	int  setMapping( nesGamePadMap_t *map );
 };
 
 extern GamePad_t GamePad[4];

--- a/src/drivers/Qt/sdl-joystick.h
+++ b/src/drivers/Qt/sdl-joystick.h
@@ -1,0 +1,58 @@
+// sdl-joystick.h
+
+#ifndef __SDL_JOYSTICK_H__
+#define __SDL_JOYSTICK_H__
+
+#include <string>
+
+#include "Qt/main.h"
+#include "Qt/input.h"
+#include "Qt/sdl.h"
+
+#define  MAX_JOYSTICKS  32
+
+struct jsDev_t
+{
+   SDL_Joystick *js;
+	SDL_GameController *gc;
+
+	jsDev_t(void);
+	//~jsDev_t(void);
+
+	void init( int idx );
+	int close(void);
+	SDL_Joystick *getJS(void);
+	bool isGameController(void);
+	bool inUse(void);
+	void print(void);
+	const char *getName(void);
+	const char *getGUID(void);
+
+	private:
+	int          devIdx;
+	std::string  guidStr;
+	std::string  name;
+};
+
+class GamePad_t
+{
+	public:
+
+	int  type;
+	int  devIdx;
+
+	ButtConfig bmap[GAMEPAD_NUM_BUTTONS];
+
+	GamePad_t(void);
+	~GamePad_t(void);
+
+	int  loadDefaults(void);
+
+	int  setMapping( const char *map );
+};
+
+extern GamePad_t GamePad[4];
+
+jsDev_t *getJoystickDevice( int devNum );
+
+#endif

--- a/src/drivers/Qt/sdl-joystick.h
+++ b/src/drivers/Qt/sdl-joystick.h
@@ -39,11 +39,15 @@ struct jsDev_t
 	bool isGameController(void);
 	bool isConnected(void);
 	void print(void);
+	int  bindPort( int idx );
+	int  unbindPort( int idx );
+	int  getBindPorts(void);
 	const char *getName(void);
 	const char *getGUID(void);
 
 	private:
 	int          devIdx;
+	int          portBindMask;
 	std::string  guidStr;
 	std::string  name;
 };
@@ -52,19 +56,18 @@ class GamePad_t
 {
 	public:
 
-	//int  type;
-	int  devIdx;
-
 	ButtConfig bmap[GAMEPAD_NUM_BUTTONS];
 
 	GamePad_t(void);
 	~GamePad_t(void);
 
+	int  init( int port, const char *guid, const char *profile = NULL );
 	const char *getGUID(void);
 
 	int  loadDefaults(void);
    int  loadProfile( const char *name, const char *guid = NULL );
 
+	int  getDeviceIndex(void){ return devIdx; }
 	int  setDeviceIndex( int devIdx );
 	int  setMapping( const char *map );
 	int  setMapping( nesGamePadMap_t *map );
@@ -75,6 +78,11 @@ class GamePad_t
    int  saveMappingToFile( const char *filename, const char *txtMap );
    int  saveCurrentMapToFile( const char *filename );
    int  deleteMapping( const char *name );
+
+	private:
+	int  devIdx;
+	int  portNum;
+
 };
 
 extern GamePad_t GamePad[4];

--- a/src/drivers/Qt/sdl-joystick.h
+++ b/src/drivers/Qt/sdl-joystick.h
@@ -11,6 +11,14 @@
 
 #define  MAX_JOYSTICKS  32
 
+struct nesGamePadMap_t
+{
+   char guid[64];
+   char name[128];
+   char btn[GAMEPAD_NUM_BUTTONS];
+   char os[64];
+};
+
 struct jsDev_t
 {
    SDL_Joystick *js;

--- a/src/drivers/Qt/sdl-joystick.h
+++ b/src/drivers/Qt/sdl-joystick.h
@@ -21,6 +21,7 @@ struct nesGamePadMap_t
    nesGamePadMap_t(void);
   ~nesGamePadMap_t(void);
 
+   void clearMapping(void);
    int parseMapping( const char *text );
 };
 
@@ -36,7 +37,7 @@ struct jsDev_t
 	int close(void);
 	SDL_Joystick *getJS(void);
 	bool isGameController(void);
-	bool inUse(void);
+	bool isConnected(void);
 	void print(void);
 	const char *getName(void);
 	const char *getGUID(void);
@@ -51,7 +52,7 @@ class GamePad_t
 {
 	public:
 
-	int  type;
+	//int  type;
 	int  devIdx;
 
 	ButtConfig bmap[GAMEPAD_NUM_BUTTONS];
@@ -59,10 +60,20 @@ class GamePad_t
 	GamePad_t(void);
 	~GamePad_t(void);
 
-	int  loadDefaults(void);
+	const char *getGUID(void);
 
+	int  loadDefaults(void);
+   int  loadProfile( const char *name, const char *guid = NULL );
+
+	int  setDeviceIndex( int devIdx );
 	int  setMapping( const char *map );
 	int  setMapping( nesGamePadMap_t *map );
+
+   int  createProfile( const char *name );
+   int  getMapFromFile( const char *filename, char *out );
+   int  getDefaultMap( char *out, const char *guid = NULL );
+   int  saveMappingToFile( const char *filename, const char *txtMap );
+   int  saveCurrentMapToFile( const char *filename );
 };
 
 extern GamePad_t GamePad[4];

--- a/src/drivers/Qt/sdl-joystick.h
+++ b/src/drivers/Qt/sdl-joystick.h
@@ -74,6 +74,7 @@ class GamePad_t
    int  getDefaultMap( char *out, const char *guid = NULL );
    int  saveMappingToFile( const char *filename, const char *txtMap );
    int  saveCurrentMapToFile( const char *filename );
+   int  deleteMapping( const char *name );
 };
 
 extern GamePad_t GamePad[4];

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -465,6 +465,11 @@ void FCEUI_SetBaseDirectory(std::string const & dir)
 {
 	BaseDirectory = dir;
 }
+/// Gets the base directory
+const char *FCEUI_GetBaseDirectory(void)
+{
+	return BaseDirectory.c_str();
+}
 
 static char *odirs[FCEUIOD__COUNT]={0,0,0,0,0,0,0,0,0,0,0,0,0};     // odirs, odors. ^_^
 


### PR DESCRIPTION
Added game pad configuration profile save feature. Added game pad button feedback indication on config window. Fixed a few uninitialized static variables in input module. Changed way button mappings are saved in config file to better match how SDL2 achieves this. Button mapping text format is now a superset built on top of SDL2 standard button mapping format.