### PR TITLE
GTK GUI Quit Logic Change

### DIFF
--- a/src/drivers/sdl/gui.cpp
+++ b/src/drivers/sdl/gui.cpp
@@ -67,6 +67,7 @@ void toggleSound (GtkWidget * check, gpointer data);
 void loadGame (void);
 void closeGame (void);
 extern Config *g_config;
+extern bool gtk_gui_run;
 
 GtkWidget *MainWindow = NULL;
 GtkWidget *evbox = NULL;
@@ -1452,21 +1453,25 @@ void openSoundConfig (void)
 
 void quit (void)
 {
-	// manually flush GTK event queue
-	while (gtk_events_pending ())
-		gtk_main_iteration_do (FALSE);
+	// Set gui run flag to false to allow main gui loop 
+	// to exit normally.
+	gtk_gui_run = false;
 
-	// this is not neccesary to be explicitly called
-	// it raises a GTK-Critical when its called
-	//gtk_main_quit();
-	FCEUI_CloseGame ();
-	FCEUI_Kill ();
-	// LoadGame() checks for an IP and if it finds one begins a network session
-	// clear the NetworkIP field so this doesn't happen unintentionally
-	g_config->setOption ("SDL.NetworkIP", "");
-	g_config->save ();
-	SDL_Quit ();
-	exit (0);
+//	// manually flush GTK event queue
+//	while (gtk_events_pending ())
+//		gtk_main_iteration_do (FALSE);
+//
+//	// this is not neccesary to be explicitly called
+//	// it raises a GTK-Critical when its called
+//	//gtk_main_quit();
+//	FCEUI_CloseGame ();
+//	FCEUI_Kill ();
+//	// LoadGame() checks for an IP and if it finds one begins a network session
+//	// clear the NetworkIP field so this doesn't happen unintentionally
+//	g_config->setOption ("SDL.NetworkIP", "");
+//	g_config->save ();
+//	SDL_Quit ();
+//	exit (0);
 }
 
 const char *Authors[] = {

--- a/src/drivers/sdl/input.cpp
+++ b/src/drivers/sdl/input.cpp
@@ -57,8 +57,8 @@ extern bool bindSavestate, frameAdvanceLagSkip, lagCounterDisplay;
 /* UsrInputType[] is user-specified.  CurInputType[] is current
         (game loading can override user settings)
 */
-static int UsrInputType[NUM_INPUT_DEVICES];
-static int CurInputType[NUM_INPUT_DEVICES];
+static int UsrInputType[NUM_INPUT_DEVICES] = { SI_GAMEPAD, SI_GAMEPAD, SI_NONE };
+static int CurInputType[NUM_INPUT_DEVICES] = { SI_GAMEPAD, SI_GAMEPAD, SI_NONE };
 static int cspec = 0;
 
 extern int gametype;

--- a/src/drivers/sdl/sdl.cpp
+++ b/src/drivers/sdl/sdl.cpp
@@ -57,6 +57,7 @@ extern bool MaxSpeed;
 int isloaded;
 
 bool turbo = false;
+bool gtk_gui_run = true;
 
 int closeFinishedMovie = 0;
 
@@ -910,7 +911,7 @@ int main(int argc, char *argv[])
 #ifdef _GTK
 	if(noGui == 0)
 	{
-		while(1)
+		while ( gtk_gui_run )
 		{
 			if(GameInfo)
 			{
@@ -926,6 +927,7 @@ int main(int argc, char *argv[])
 				gtk_main_iteration_do(FALSE);
 			}
 		}
+		printf("Exiting GUI Main Loop...\n");
 	}
 	else
 	{
@@ -938,11 +940,20 @@ int main(int argc, char *argv[])
 		DoFun(frameskip, periodic_saves);
 	}
 #endif
+	printf("Closing Game...\n");
 	CloseGame();
 
+	printf("Exiting Infrastructure...\n");
 	// exit the infrastructure
 	FCEUI_Kill();
 	SDL_Quit();
+
+	// LoadGame() checks for an IP and if it finds one begins a network session
+	// clear the NetworkIP field so this doesn't happen unintentionally
+	g_config->setOption ("SDL.NetworkIP", "");
+	g_config->save ();
+
+	printf("Done!\n");
 	return 0;
 }
 


### PR DESCRIPTION
Modified GTK GUI quit logic to just set a flag in the quit callback function to allow the gui exit its main loop under normal conditions and then proceed with an orderly cleanup/shutdown outside of the GTK event loop. This is an attempt to fix issue #147.