### PR TITLE
GTK/SDL GUI added to cmake build

### DIFF
--- a/pipelines/debpkg.pl
+++ b/pipelines/debpkg.pl
@@ -11,8 +11,8 @@ my $PKG_OUTPUT_FILE="fceux-$VERSION-$ARCH.deb";
 # Start by auto figuring out dependencies of the executable.
 # the rest of the package creation is trival.
 my $SO_LIST="";
-$SO_LIST+=`objdump -x  $INSTALL_PREFIX/usr/bin/fceux`;
-$SO_LIST+=`objdump -x  $INSTALL_PREFIX/usr/bin/fceux-gtk`;
+$SO_LIST=`objdump -x  $INSTALL_PREFIX/usr/bin/fceux`;
+$SO_LIST= $SO_LIST . `objdump -x  $INSTALL_PREFIX/usr/bin/fceux-gtk`;
 
 #print "$SO_LIST";
 

--- a/pipelines/debpkg.pl
+++ b/pipelines/debpkg.pl
@@ -10,7 +10,9 @@ my $PKG_OUTPUT_FILE="fceux-$VERSION-$ARCH.deb";
 
 # Start by auto figuring out dependencies of the executable.
 # the rest of the package creation is trival.
-my $SO_LIST=`objdump -x  $INSTALL_PREFIX/usr/bin/fceux`;
+my $SO_LIST="";
+$SO_LIST+=`objdump -x  $INSTALL_PREFIX/usr/bin/fceux`;
+$SO_LIST+=`objdump -x  $INSTALL_PREFIX/usr/bin/fceux-gtk`;
 
 #print "$SO_LIST";
 

--- a/pipelines/linux_build.sh
+++ b/pipelines/linux_build.sh
@@ -144,6 +144,16 @@ else
    exit 1;
 fi
 
+if [ -e $INSTALL_PREFIX/usr/bin/fceux-gtk ]; then
+   echo '**************************************************************'
+   echo 'Printing Shared Object Dependencies for fceux-gtk Executable'
+   echo '**************************************************************'
+   ldd  $INSTALL_PREFIX/usr/bin/fceux-gtk
+else
+   echo "Error: Executable Failed to build: $INSTALL_PREFIX/usr/bin/fceux-gtk";
+   exit 1;
+fi
+
 echo '**************************************************************'
 echo 'Printing To Be Packaged Files '
 echo '**************************************************************'

--- a/pipelines/linux_build.sh
+++ b/pipelines/linux_build.sh
@@ -92,14 +92,24 @@ mkdir -p $INSTALL_PREFIX/usr;
 #scons   --clean
 #scons   GTK3=1   SYSTEM_LUA=1   SYSTEM_MINIZIP=1   CREATE_AVI=1  install  --prefix=$INSTALL_PREFIX/usr
 echo "Num CPU: `nproc`";
-mkdir build; cd build;
-#qmake PREFIX=$INSTALL_PREFIX/usr  ..
+mkdir buildQT; cd buildQT;
 cmake  \
    -DCMAKE_BUILD_TYPE=Release  \
    -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX/usr \
    -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
 	..
-make -j `nproc` 
+make -j `nproc`
+make  install
+
+cd ..;
+mkdir buildGTK; cd buildGTK;
+cmake  \
+   -DGTK=1 \
+   -DCMAKE_BUILD_TYPE=Release  \
+   -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX/usr \
+   -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+	..
+make -j `nproc`
 make  install
 
 # Install Files

--- a/pipelines/linux_build.sh
+++ b/pipelines/linux_build.sh
@@ -60,8 +60,8 @@ pkg-config --cflags --libs  minizip
 #echo '****************************************'
 #echo 'Install Dependency libgtk-3-dev'
 #echo '****************************************'
-#sudo apt-get --assume-yes  install libgtk-3-dev
-#pkg-config --cflags --libs  gtk+-3.0
+sudo apt-get --assume-yes  install libgtk-3-dev
+pkg-config --cflags --libs  gtk+-3.0
 #
 ## Install GTK+-3 Sourceview
 #sudo apt-get --assume-yes  install libgtksourceview-3.0-dev

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,12 @@
 
+if ( ${GTK} )
+set( APP_NAME fceux-gtk)
+else()
+set( APP_NAME fceux)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
-
-set( APP_NAME fceux)
+endif()
 
 if(WIN32)
   set(SOURCES ${SRC_CORE} ${SRC_DRIVERS_COMMON} ${SRC_DRIVERS_WIN})
@@ -27,14 +30,22 @@ else(WIN32)
   # Use the built-in cmake find_package functions to find dependencies
   # Use package PkgConfig to detect headers/library what find_package cannot find.
   find_package(PkgConfig REQUIRED)
-  find_package(Qt5 COMPONENTS Widgets OpenGL REQUIRED)
   find_package(OpenGL REQUIRED)
   find_package(ZLIB REQUIRED)
 
-  add_definitions( ${Qt5Widgets_DEFINITIONS}  )
-  include_directories( ${Qt5Widgets_INCLUDE_DIRS} )
+  add_definitions( -Wall  -Wno-write-strings  -Wno-sign-compare  -Wno-parentheses  -Wno-unused-local-typedefs  -fPIC )
 
-  add_definitions( -D__QT_DRIVER__  -Wall  -Wno-write-strings  -Wno-sign-compare  -Wno-parentheses  -Wno-unused-local-typedefs  -fPIC -DQT_DEPRECATED_WARNINGS )
+  if ( ${GTK} )
+     pkg_check_modules( GTK3 REQUIRED gtk+-3.0)
+     pkg_check_modules( X11  REQUIRED x11)
+     add_definitions( ${GTK3_CFLAGS}  ${X11_CFLAGS} )
+     add_definitions( -D_GTK -DOPENGL )
+  else(${GTK})
+     find_package(Qt5 COMPONENTS Widgets OpenGL REQUIRED)
+     add_definitions( ${Qt5Widgets_DEFINITIONS}  )
+     include_directories( ${Qt5Widgets_INCLUDE_DIRS} )
+     add_definitions( -D__QT_DRIVER__  -DQT_DEPRECATED_WARNINGS )
+  endif()
 
   # Check for libminizip
   pkg_check_modules( MINIZIP REQUIRED minizip)
@@ -381,6 +392,24 @@ set(SRC_DRIVERS_COMMON
   ${CMAKE_CURRENT_SOURCE_DIR}/drivers/videolog/rgbtorgb.cpp
 )
 
+if ( ${GTK} )
+set(SRC_DRIVERS_SDL
+  ${CMAKE_CURRENT_SOURCE_DIR}/drivers/sdl/cheat.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/drivers/sdl/config.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/drivers/sdl/debugger.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/drivers/sdl/glxwin.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/drivers/sdl/gui.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/drivers/sdl/input.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/drivers/sdl/memview.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/drivers/sdl/ramwatch.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/drivers/sdl/sdl.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/drivers/sdl/sdl-joystick.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/drivers/sdl/sdl-sound.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/drivers/sdl/sdl-throttle.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/drivers/sdl/sdl-video.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/drivers/sdl/unix-netplay.cpp
+)
+else()
 set(SRC_DRIVERS_SDL
   ${CMAKE_CURRENT_SOURCE_DIR}/drivers/Qt/main.cpp  
   ${CMAKE_CURRENT_SOURCE_DIR}/drivers/Qt/ConsoleWindow.cpp  
@@ -407,6 +436,7 @@ set(SRC_DRIVERS_SDL
   ${CMAKE_CURRENT_SOURCE_DIR}/drivers/Qt/sdl-throttle.cpp  
   ${CMAKE_CURRENT_SOURCE_DIR}/drivers/Qt/unix-netplay.cpp
 )
+endif()
 
 set(SOURCES ${SRC_CORE} ${SRC_DRIVERS_COMMON} ${SRC_DRIVERS_SDL})
 
@@ -427,11 +457,27 @@ add_executable(  ${APP_NAME}  MACOSX_BUNDLE ${APP_ICON} ${SOURCES} ../resources.
 	${CMAKE_CURRENT_BINARY_DIR}/fceux_git_info.cpp)
 
 else()
-add_executable(  ${APP_NAME}  ${SOURCES} ../resources.qrc 
-	${CMAKE_CURRENT_BINARY_DIR}/fceux_git_info.cpp)
+
+   if ( ${GTK} )
+      add_executable(  ${APP_NAME}  ${SOURCES} 
+   	   ${CMAKE_CURRENT_BINARY_DIR}/fceux_git_info.cpp)
+   else()
+      add_executable(  ${APP_NAME}  ${SOURCES} ../resources.qrc 
+   	   ${CMAKE_CURRENT_BINARY_DIR}/fceux_git_info.cpp)
+   endif()
 endif()
 
-target_link_libraries( fceux  
+if ( ${GTK} )
+   target_link_libraries( ${APP_NAME}  
+   ${GTK3_LDFLAGS} ${X11_LDFLAGS}
+   ${OPENGL_LDFLAGS}
+ 	${SDL2_LDFLAGS}
+	${MINIZIP_LDFLAGS} ${ZLIB_LIBRARIES}
+	${LUA_LDFLAGS}
+ 	${SYS_LIBS}
+)
+else()
+target_link_libraries( ${APP_NAME}  
    ${Qt5Widgets_LIBRARIES}
    ${Qt5OpenGL_LIBRARIES}
    ${OPENGL_LDFLAGS}
@@ -440,6 +486,7 @@ target_link_libraries( fceux
 	${LUA_LDFLAGS}
  	${SYS_LIBS}
 )
+endif()
 
 if (APPLE)
 

--- a/src/drivers/Qt/fceuWrapper.cpp
+++ b/src/drivers/Qt/fceuWrapper.cpp
@@ -15,6 +15,7 @@
 #include "Qt/nes_shm.h"
 #include "Qt/unix-netplay.h"
 #include "Qt/ConsoleWindow.h"
+#include "Qt/fceux_git_info.h"
 
 #include "common/cheat.h"
 #include "../../fceu.h"
@@ -410,6 +411,8 @@ static void ShowUsage(const char *prog)
 	SDL_GetVersion(&v);
 	printf("Linked with SDL version %d.%d.%d\n", v.major, v.minor, v.patch);
   	printf("Compiled with QT version %d.%d.%d\n", QT_VERSION_MAJOR, QT_VERSION_MINOR, QT_VERSION_PATCH );
+	printf("git URL: %s\n", fceu_get_git_url() );
+	printf("git Rev: %s\n", fceu_get_git_rev() );
 	
 }
 

--- a/src/drivers/sdl/fceux_git_info.h
+++ b/src/drivers/sdl/fceux_git_info.h
@@ -1,0 +1,4 @@
+// fceux_git_info.h
+
+const char *fceu_get_git_url(void);
+const char *fceu_get_git_rev(void);

--- a/src/drivers/sdl/gui.cpp
+++ b/src/drivers/sdl/gui.cpp
@@ -1451,8 +1451,11 @@ void openSoundConfig (void)
 	return;
 }
 
-void quit (void)
+static void mainMenuQuitCB(
+		GtkMenuItem *menuitem,
+      gpointer     user_data)
 {
+	printf("Main Menu Quit\n");
 	// Set gui run flag to false to allow main gui loop 
 	// to exit normally.
 	gtk_gui_run = false;
@@ -1472,6 +1475,30 @@ void quit (void)
 //	g_config->save ();
 //	SDL_Quit ();
 //	exit (0);
+}
+
+static gboolean deleteMainWindowCB(
+			GtkWidget *widget,
+         GdkEvent  *event,
+         gpointer   user_data)
+{
+	printf("Delete Main Window Requested...\n");
+
+	gtk_gui_run = false;
+
+	return(TRUE);
+}
+
+static gboolean destroyMainWindowCB(
+			GtkWidget *widget,
+         GdkEvent  *event,
+         gpointer   user_data)
+{
+	printf("Destroy Main Window\n");
+
+	gtk_gui_run = false;
+
+	return(FALSE);
 }
 
 const char *Authors[] = {
@@ -2612,7 +2639,7 @@ static GtkWidget *CreateMenubar (GtkWidget * window)
 	//-File --> Quit ------------------
 	item = gtk_menu_item_new_with_label ("Quit");
 
-	g_signal_connect (item, "activate", G_CALLBACK (quit), NULL);
+	g_signal_connect (item, "activate", G_CALLBACK (mainMenuQuitCB), NULL);
 
 	gtk_widget_add_accelerator (item, "activate", accel_group,
 				    GDK_KEY_q, GDK_CONTROL_MASK,
@@ -3683,8 +3710,8 @@ int InitGTKSubsystem (int argc, char **argv)
 			  G_CALLBACK (handleMouseClick), NULL);
 
 	// signal handlers
-	g_signal_connect (MainWindow, "delete-event", quit, NULL);
-	g_signal_connect (MainWindow, "destroy-event", quit, NULL);
+	g_signal_connect (MainWindow, "delete-event", G_CALLBACK(deleteMainWindowCB), NULL);
+	g_signal_connect (MainWindow, "destroy-event", G_CALLBACK(destroyMainWindowCB), NULL);
 
 	g_signal_connect (evbox, "configure-event",
 			  G_CALLBACK (handle_resize), NULL);

--- a/src/drivers/sdl/gui.cpp
+++ b/src/drivers/sdl/gui.cpp
@@ -19,6 +19,7 @@
 #include "memview.h"
 #include "ramwatch.h"
 #include "debugger.h"
+#include "fceux_git_info.h"
 
 #ifdef _S9XLUA_H
 #include "../../fceulua.h"
@@ -1503,6 +1504,7 @@ static gboolean destroyMainWindowCB(
 
 const char *Authors[] = {
 	"Linux/SDL Developers:",
+	" mjbudd77",
 	" Lukas Sabota //punkrockguy318", " Soules", " Bryan Cain", " radsaq",
 		" Shinydoofy",
 	"FceuX 2.0 Developers:",
@@ -1523,11 +1525,16 @@ const char *Authors[] = {
 
 void openAbout (void)
 {
+	char versionString[512];
+
 	GdkPixbuf *logo = gdk_pixbuf_new_from_xpm_data (icon_xpm);
+
+	sprintf( versionString, "%s\ngit URL: %s\ngit Rev: %s",
+		  	FCEU_VERSION_STRING, fceu_get_git_url(), fceu_get_git_rev() );
 
 	gtk_show_about_dialog (GTK_WINDOW (MainWindow),
 			       "program-name", "fceuX",
-			       "version", FCEU_VERSION_STRING,
+			       "version", versionString,
 			       "copyright", "© 2016 FceuX development team",
 			       "license", "GPL-2; See COPYING",
 			       //"license-type", GTK_LICENSE_GPL_2_0,

--- a/src/drivers/sdl/gui.h
+++ b/src/drivers/sdl/gui.h
@@ -59,7 +59,6 @@ void setStateMenuItem( int i );
 
 void openVideoConfig();
 void openSoundConfig();
-void quit ();
 void openAbout ();
 
 void emuReset ();

--- a/src/drivers/sdl/sdl-video.cpp
+++ b/src/drivers/sdl/sdl-video.cpp
@@ -51,6 +51,10 @@
 #include <cstring>
 #include <cstdlib>
 
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+#define  LSB_FIRST 
+#endif
+
 // GLOBALS
 extern Config *g_config;
 

--- a/src/drivers/sdl/sdl.cpp
+++ b/src/drivers/sdl/sdl.cpp
@@ -35,6 +35,8 @@
 #include "gui.h"
 #endif
 
+#include "fceux_git_info.h"
+
 #include <unistd.h>
 #include <csignal>
 #include <cstring>
@@ -182,6 +184,8 @@ static void ShowUsage(char *prog)
 	printf("Compiled with GTK version %d.%d.%d\n", GTK_MAJOR_VERSION, GTK_MINOR_VERSION, GTK_MICRO_VERSION );
 	//printf("Linked with GTK version %d.%d.%d\n", GTK_MAJOR_VERSION, GTK_MINOR_VERSION, GTK_MICRO_VERSION );
 #endif
+	printf("git URL: %s\n", fceu_get_git_url() );
+	printf("git Rev: %s\n", fceu_get_git_rev() );
 	
 }
 

--- a/src/drivers/sdl/sdl.cpp
+++ b/src/drivers/sdl/sdl.cpp
@@ -948,6 +948,20 @@ int main(int argc, char *argv[])
 	FCEUI_Kill();
 	SDL_Quit();
 
+#ifdef _GTK
+	usleep(50000);
+	if ( MainWindow != NULL )
+	{
+		printf("Destroying GUI Window...\n");
+		gtk_widget_destroy( MainWindow ); MainWindow = NULL;
+	}
+	usleep(50000);
+	while(gtk_events_pending())
+	{
+		//printf("Processing the last of the events...\n");
+		gtk_main_iteration_do(FALSE);
+	}
+#endif
 	// LoadGame() checks for an IP and if it finds one begins a network session
 	// clear the NetworkIP field so this doesn't happen unintentionally
 	g_config->setOption ("SDL.NetworkIP", "");


### PR DESCRIPTION
Both the QT/SDL and GTK/SDL versions of fceux are now buildable via cmake. Hopefully now scons can now die. Since it seems that some users are particular about QT vs GTK (and KDE vs Gnome), I have added GTK/SDL GUI build to linux pipeline in addition to QT/SDL. Both versions of fceux are packaged into the Ubuntu 20.04 deb package created by the pipeline. Also, added git URL and Revision info to the GTK/SDL build executable.