### PR TITLE
Added logic to generate default game pad mappings for new controllers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -395,6 +395,7 @@ set(SRC_DRIVERS_COMMON
   ${CMAKE_CURRENT_SOURCE_DIR}/drivers/common/scale3x.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/drivers/common/scalebit.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/drivers/common/vidblit.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/drivers/common/os_utils.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/drivers/common/nes_ntsc.c
   ${CMAKE_CURRENT_SOURCE_DIR}/drivers/videolog/nesvideos-piece.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/drivers/videolog/rgbtorgb.cpp

--- a/src/drivers/Qt/sdl-joystick.cpp
+++ b/src/drivers/Qt/sdl-joystick.cpp
@@ -151,6 +151,47 @@ void jsDev_t::init( int idx )
 
 	guidStr.assign( stmp );
 
+	// If game controller, save default mapping if it does not already exist.
+	if ( gc )
+	{
+   	QDir dir;
+		QFile defaultMapFile;
+   	std::string path;
+   	const char *baseDir = FCEUI_GetBaseDirectory();
+		
+   	path = std::string(baseDir) + "/input/" + guidStr;
+
+   	dir.mkpath( QString::fromStdString(path) );
+
+   	path += "/default.txt";
+
+		defaultMapFile.setFileName( QString::fromStdString(path) );
+
+		if ( !defaultMapFile.exists() )
+		{
+			FILE *fp;
+
+			fp = ::fopen( path.c_str(), "w" );
+
+			if ( fp != NULL )
+			{
+				const char *defaultMap;
+
+				defaultMap = SDL_GameControllerMapping(gc);
+
+				if ( defaultMap )
+				{
+					//printf("GameController Mapping: %s\n", defaultMap );
+					fprintf( fp, "%s", defaultMap );
+				}
+				::fclose(fp); 
+			}
+		}
+		//else 
+		//{
+		//	printf("GameController Mapping Exists: '%s'\n", path.c_str() );
+		//}
+	}
 }
 
 void jsDev_t::print(void)

--- a/src/drivers/common/os_utils.cpp
+++ b/src/drivers/common/os_utils.cpp
@@ -1,0 +1,87 @@
+// os_util.cpp
+#include <stdio.h>
+#include <stdlib.h>
+
+#if defined(WIN32)
+#include <windows.h>
+#else
+#include <errno.h>
+#include <sys/stat.h>
+#endif
+
+#include "common/os_utils.h"
+//************************************************************
+int fceu_mkdir( const char *path )
+{
+	int retval;
+#if defined(WIN32)
+	retval = mkdir(path);
+	chmod(path, 755);
+#else
+	retval = mkdir(path, S_IRWXU);
+
+	if ( retval != 0 )
+	{	
+		if ( errno == EEXIST )
+		{
+			//printf("Path Exists: '%s'\n", path);
+			retval = 0;
+		}
+	}
+#endif
+	return retval;
+}
+//************************************************************
+int fceu_mkpath( const char *path )
+{
+	int i, retval = 0;
+	char p[512];
+
+	i=0;
+	while ( path[i] != 0 )
+	{
+		if ( path[i] == '/' )
+		{
+			if ( i > 0 )
+			{
+				p[i] = 0;
+
+				retval = fceu_mkdir( p );
+
+				if ( retval )
+				{
+					return retval;
+				}
+			}
+		}
+		p[i] = path[i]; i++;
+	}
+	p[i] = 0;
+
+	retval = fceu_mkdir( p );
+
+	return retval;
+}
+//************************************************************
+bool fceu_file_exists( const char *filepath )
+{
+#ifdef WIN32
+	FILE *fp;
+	fp = ::fopen( filename, "r" );
+
+	if ( fp != NULL )
+	{
+		::fclose(fp);
+		return true;
+	}
+#else
+	struct stat sb;
+
+	if ( stat( filepath, &sb ) == 0 )
+	{
+		return true;
+	}
+#endif
+	return false;
+}
+//************************************************************

--- a/src/drivers/common/os_utils.h
+++ b/src/drivers/common/os_utils.h
@@ -1,0 +1,9 @@
+// os_utils.h
+//
+
+int fceu_mkdir( const char *path );
+
+int fceu_mkpath( const char *path );
+
+bool fceu_file_exists( const char *filepath );
+

--- a/src/drivers/sdl/sdl-joystick.cpp
+++ b/src/drivers/sdl/sdl-joystick.cpp
@@ -25,6 +25,7 @@
 //#include <QDir>
 #include "sdl/sdl.h"
 #include "sdl/sdl-joystick.h"
+#include "common/os_utils.h"
 
 #include <cstdlib>
 #include <unistd.h>
@@ -151,6 +152,39 @@ void jsDev_t::init( int idx )
 
 	guidStr.assign( stmp );
 
+	// If game controller, save default mapping if it does not already exist.
+	if ( gc )
+	{
+   	std::string path;
+   	const char *baseDir = FCEUI_GetBaseDirectory();
+		
+   	path = std::string(baseDir) + "/input/" + guidStr;
+
+   	fceu_mkpath( path.c_str() );
+
+   	path += "/default.txt";
+
+		if ( !fceu_file_exists( path.c_str() ) )
+		{
+			FILE *fp;
+
+			fp = ::fopen( path.c_str(), "w" );
+
+			if ( fp != NULL )
+			{
+				const char *defaultMap;
+
+				defaultMap = SDL_GameControllerMapping(gc);
+
+				if ( defaultMap )
+				{
+					//printf("GameController Mapping: %s\n", defaultMap );
+					fprintf( fp, "%s", defaultMap );
+				}
+				::fclose(fp); 
+			}
+		}
+	}
 }
 
 void jsDev_t::print(void)
@@ -679,7 +713,7 @@ int GamePad_t::saveCurrentMapToFile( const char *name )
    }
    path = std::string(baseDir) + "/input/" + std::string(guid);
 
-   //dir.mkpath( QString::fromStdString(path) );
+   fceu_mkpath( path.c_str() );
 
    path += "/" + std::string(name) + ".txt";
 
@@ -767,7 +801,7 @@ int GamePad_t::createProfile( const char *name )
    }
    path = std::string(baseDir) + "/input/" + std::string(guid);
 
-   //dir.mkpath( QString::fromStdString(path) );
+   fceu_mkpath( path.c_str() );
    //printf("DIR: '%s'\n", path.c_str() );
 
    //path += "/" + std::string(name) + ".txt";


### PR DESCRIPTION
In the SDL (both Qt and GTK) port, if a new game controller is plugged in and does not have a default mapping yet created for it, then create one upon connection.