### PR TITLE
SDL Qt5 GUI Hex Editor Bookmark Functionality

### DIFF
--- a/src/drivers/Qt/ConsoleUtilities.cpp
+++ b/src/drivers/Qt/ConsoleUtilities.cpp
@@ -59,7 +59,7 @@ int getFileBaseName( const char *filepath, char *base )
 	{
 		if ( (filepath[i] == '/') || (filepath[i] == '\\') )
 		{
-			j = i;
+			j = i+1;
 		}
 		i++;
 	}

--- a/src/drivers/Qt/HexEditor.cpp
+++ b/src/drivers/Qt/HexEditor.cpp
@@ -13,6 +13,7 @@
 #include <QFileDialog>
 #include <QColorDialog>
 #include <QInputDialog>
+#include <QMessageBox>
 
 #include "../../types.h"
 #include "../../fceu.h"
@@ -738,9 +739,23 @@ HexEditorDialog_t::~HexEditorDialog_t(void)
 //----------------------------------------------------------------------------
 void HexEditorDialog_t::removeAllBookmarks(void)
 {
-	hbm.removeAll();
+	int ret;
+	QMessageBox mbox(this);
 
-	populateBookmarkMenu();
+	mbox.setWindowTitle( tr("Bookmarks") );
+	mbox.setText( tr("Remove All Bookmarks?") );
+	mbox.setIcon( QMessageBox::Question );
+	mbox.setStandardButtons( QMessageBox::Cancel | QMessageBox::Ok );
+
+	ret = mbox.exec();
+
+	//printf("Ret: %i \n", ret );
+	if ( ret == QMessageBox::Ok )
+	{
+		hbm.removeAll();
+
+		populateBookmarkMenu();
+	}
 }
 //----------------------------------------------------------------------------
 void HexEditorDialog_t::populateBookmarkMenu(void)

--- a/src/drivers/Qt/HexEditor.cpp
+++ b/src/drivers/Qt/HexEditor.cpp
@@ -379,7 +379,7 @@ HexBookMarkMenuAction::HexBookMarkMenuAction(QString desc, QWidget *parent)
 //----------------------------------------------------------------------------
 HexBookMarkMenuAction::~HexBookMarkMenuAction(void)
 {
-
+	//printf("Hex Bookmark Menu Action Deleted\n");
 }
 //----------------------------------------------------------------------------
 void HexBookMarkMenuAction::activateCB(void)
@@ -597,7 +597,7 @@ void HexEditorDialog_t::populateBookmarkMenu(void)
 	bookmarkMenu->clear();
 
 	// Bookmarks -> Remove All Bookmarks
-	act = new QAction(tr("Remove All Bookmarks"), this);
+	act = new QAction(tr("Remove All Bookmarks"), bookmarkMenu);
    //act->setShortcuts(QKeySequence::Open);
    act->setStatusTip(tr("Remove All Bookmarks"));
    connect(act, SIGNAL(triggered(void)), this, SLOT(removeAllBookmarks(void)) );
@@ -611,7 +611,7 @@ void HexEditorDialog_t::populateBookmarkMenu(void)
 
 		if ( b )
 		{
-			hAct = new HexBookMarkMenuAction(tr(b->desc), this);
+			hAct = new HexBookMarkMenuAction(tr(b->desc), bookmarkMenu);
    		bookmarkMenu->addAction(hAct);
 			hAct->bm = b; hAct->qedit = editor;
    		connect(hAct, SIGNAL(triggered(void)), hAct, SLOT(activateCB(void)) );

--- a/src/drivers/Qt/HexEditor.h
+++ b/src/drivers/Qt/HexEditor.h
@@ -3,9 +3,13 @@
 
 #pragma once
 
+#include <list>
+#include <vector>
+
 #include <QWidget>
 #include <QDialog>
 #include <QTimer>
+#include <QAction>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QComboBox>
@@ -41,6 +45,52 @@ struct memBlock_t
    int  _maxLines;
 	int (*memAccessFunc)( unsigned int offset);
 };
+
+class HexBookMark
+{
+	public:
+		HexBookMark(void);
+		~HexBookMark(void);
+
+	int  addr;
+	int  mode;
+	char desc[64];
+};
+
+class HexBookMarkManager_t
+{
+	public:
+		HexBookMarkManager_t(void);
+		~HexBookMarkManager_t(void);
+
+		void removeAll(void);
+		int  addBookMark( int addr, int mode, const char *desc );
+		int  size(void);
+		HexBookMark *getBookMark( int index );
+	private:
+		void updateVector(void);
+		std::list <HexBookMark*> ls;
+		std::vector <HexBookMark*> v;
+};
+
+class QHexEdit;
+
+class HexBookMarkMenuAction : public QAction
+{
+   Q_OBJECT
+
+	public:
+		HexBookMarkMenuAction( QString desc, QWidget *parent = 0);
+		~HexBookMarkMenuAction(void);
+
+		QHexEdit    *qedit;
+		HexBookMark *bm;
+	public slots:
+		void activateCB(void);
+
+};
+
+class HexEditorDialog_t;
 
 class QHexEdit : public QWidget
 {
@@ -93,6 +143,8 @@ class QHexEdit : public QWidget
 		QColor      highLightColor[ HIGHLIGHT_ACTIVITY_NUM_COLORS ];
 		QColor      rvActvTextColor[ HIGHLIGHT_ACTIVITY_NUM_COLORS ];
 
+		HexEditorDialog_t *parent;
+
 		uint64_t total_instructions_lp;
 
       int viewMode;
@@ -119,6 +171,7 @@ class QHexEdit : public QWidget
       int editValue;
       int editMask;
 		int jumpToRomValue;
+		int ctxAddr;
 
 		bool cursorBlink;
 		bool reverseVideo;
@@ -126,6 +179,7 @@ class QHexEdit : public QWidget
 
 	private slots:
 		void jumpToROM(void);
+		void addBookMarkCB(void);
 
 };
 
@@ -137,11 +191,11 @@ class HexEditorDialog_t : public QDialog
 		HexEditorDialog_t(QWidget *parent = 0);
 		~HexEditorDialog_t(void);
 
-	protected:
-		void closeEvent(QCloseEvent *bar);
-
 		void gotoAddress(int newAddr);
 		void populateBookmarkMenu(void);
+	protected:
+
+		void closeEvent(QCloseEvent *bar);
 
 		QScrollBar *vbar;
 		QScrollBar *hbar;
@@ -168,4 +222,5 @@ class HexEditorDialog_t : public QDialog
 		void actvHighlightRVCB(bool value); 
 		void pickForeGroundColor(void);
 		void pickBackGroundColor(void);
+		void removeAllBookmarks(void);
 };

--- a/src/drivers/Qt/HexEditor.h
+++ b/src/drivers/Qt/HexEditor.h
@@ -67,6 +67,8 @@ class HexBookMarkManager_t
 		int  addBookMark( int addr, int mode, const char *desc );
 		int  size(void);
 		HexBookMark *getBookMark( int index );
+		int  saveToFile(void);
+		int  loadFromFile(void);
 	private:
 		void updateVector(void);
 		std::list <HexBookMark*> ls;
@@ -224,3 +226,6 @@ class HexEditorDialog_t : public QDialog
 		void pickBackGroundColor(void);
 		void removeAllBookmarks(void);
 };
+
+void hexEditorLoadBookmarks(void);
+void hexEditorSaveBookmarks(void);

--- a/src/drivers/Qt/fceuWrapper.cpp
+++ b/src/drivers/Qt/fceuWrapper.cpp
@@ -14,6 +14,7 @@
 #include "Qt/sdl-video.h"
 #include "Qt/nes_shm.h"
 #include "Qt/unix-netplay.h"
+#include "Qt/HexEditor.h"
 #include "Qt/ConsoleWindow.h"
 #include "Qt/fceux_git_info.h"
 
@@ -231,6 +232,8 @@ int LoadGame(const char *path)
 		return 0;
 	}
 
+	hexEditorLoadBookmarks();
+
     int state_to_load;
     g_config->getOption("SDL.AutoLoadState", &state_to_load);
     if (state_to_load >= 0 && state_to_load < 10){
@@ -277,6 +280,7 @@ CloseGame(void)
 	if(!isloaded) {
 		return(0);
 	}
+	hexEditorSaveBookmarks();
 
     int state_to_save;
     g_config->getOption("SDL.AutoSaveState", &state_to_save);

--- a/web/osx.html
+++ b/web/osx.html
@@ -59,37 +59,23 @@
 
 </div>
 	<div id="page_content">
-    To compile FCEUX in osx, you must have fink or macports. The FCEUX developers recommend fink, since that's what they use, but then again, the only time they compile software on osx is when folks come nagging.<p>
+    To run FCEUX in Mac OSX, you must have the following library dependencies installed on your system:
        <p>
-first, install the prerequisites.<p>
-<p>
-macports requires these prerequisites: scons, libsdl, zenity, lua, gtk2<p>
-fink requires these prerequisites: try all the same ones as macports, but i know at least one of them is named gtk+2 instead. please report your results.<p>
-<p>
-Building instructions for fink:<p>
-<p>
-CFLAGS=-I/sw/include LDFLAGS=-L/sw/lib scons<p>
-if you are getting link errors about 64bitness then your system is compiling fceux as 64bit but fink is providing i386 libraries. you need to force fceux to compile 32 bits:<p>
-CFLAGS="-I/sw/include -arch i386" LDFLAGS="-L/sw/lib -arch i386" scons<p>
-<p>
-None of the modifications listed at the paperkettle URL were necessary in our latest fink test only 18-jul-2010<p>
-<p>
-This URL is a little old, but he got FCEUX compiling via fink<p>
-http://beesbuzz.biz/blog/e/2009/04/14-how_to_build_fceux_for_mac_os_x.php<p>
-<p>
-Building instructions for macports:<p>
-<p>
-CFLAGS=-I/opt/local/include LDFLAGS=-L/opt/local/lib scons<p>
-<p>
-This URL is fresh, and he got FCEUX compiling via macports:<p>
-http://www.paperkettle.com/blog/2010/07/17/fceux-2-14a-compiled-on-mac-osx-10-6/<p>
-<p>
----<p>
-<p>
-At any given time while fooling around you may discover that scons begins behaving irrationally. To fix this, try deleting .sconsign.dblite which will clear out its memory of what has come before.<p>
-<p>
-To clean your scons build, issue the main scons build command as discussed above with the -c parameter<p>
-
+		 Qt5, SDL2, minizip, and zlib
+		 <p>
+		 If you are attempting to use the appveyor pipeline autobuild of fceux, you must install these
+		 dependencies via the home brew package management tool. The following commands will install
+		 the necessary dependencies to run the autobuild:
+		 <pre>
+		 brew install qt5
+		 brew install sdl2
+		 brew install minizip
+		 </pre>
+		 If you are attempting to compile fceux, you can either install the dependencies via home brew
+		 or you can install the dmg packages available from the Qt and SDL websites. The cmake and make 
+		 build tools are required to compile fceux. See the README file in the root directory of the 
+		 project for build instructions. You can also look at what is being done in the ./pipelines/macOS_build.sh
+		 script if you wish to build fceux in the same way the autobuild does.
 	</div>
 </div>
 


### PR DESCRIPTION
Added hex editor address bookmark functionality to the SDL Qt5 GUI. Also updated Mac OSX build web page. Added instructions on how to install the necessary dependencies to run the appveyor autobuild of fceux on Mac OSX.