### PR TITLE
Added a circular buffer to the Qt Lua output console to allow for mes…

### DIFF
--- a/src/drivers/Qt/LuaControl.h
+++ b/src/drivers/Qt/LuaControl.h
@@ -31,6 +31,7 @@ class LuaControlDialog_t : public QDialog
 	protected:
 		void closeEvent(QCloseEvent *bar);
 
+      QTimer      *periodicTimer;
 		QLineEdit   *scriptPath;
 		QLineEdit   *scriptArgs;
 		QPushButton *browseButton;
@@ -42,6 +43,7 @@ class LuaControlDialog_t : public QDialog
    public slots:
       void closeWindow(void);
 	private slots:
+      void updatePeriodic(void);
 		void openLuaScriptFile(void);
 		void startLuaScript(void);
 		void stopLuaScript(void);


### PR DESCRIPTION
…sages to be passed in a thread safe way from the emulation thread to the GUI thread. This fixes the crash issue mentioned in Issue #190.