### PR TITLE
Qt GUI Minor Fixes and Style Improvements

### DIFF
--- a/src/drivers/Qt/ConsoleVideoConf.cpp
+++ b/src/drivers/Qt/ConsoleVideoConf.cpp
@@ -7,6 +7,7 @@
 #include "Qt/dface.h"
 #include "Qt/config.h"
 #include "Qt/fceuWrapper.h"
+#include "Qt/ConsoleWindow.h"
 #include "Qt/ConsoleVideoConf.h"
 
 //----------------------------------------------------
@@ -41,6 +42,8 @@ ConsoleVideoConfDialog_t::ConsoleVideoConfDialog_t(QWidget *parent)
 	gl_LF_chkBox  = new QCheckBox( tr("Enable OpenGL Linear Filter") );
 
 	setCheckBoxFromProperty( gl_LF_chkBox  , "SDL.OpenGLip");
+
+	connect(gl_LF_chkBox , SIGNAL(stateChanged(int)), this, SLOT(openGL_linearFilterChanged(int)) );
 
 	main_vbox->addWidget( gl_LF_chkBox );
 
@@ -162,6 +165,21 @@ void  ConsoleVideoConfDialog_t::setComboBoxFromProperty( QComboBox *cbx, const c
 			cbx->setCurrentIndex(i); break;
 		}
 	}
+}
+//----------------------------------------------------
+void ConsoleVideoConfDialog_t::openGL_linearFilterChanged( int value )
+{
+   bool opt =  (value != Qt::Unchecked);
+   g_config->setOption("SDL.OpenGLip", opt );
+	g_config->save ();
+
+   if ( consoleWindow != NULL )
+   {
+      if ( consoleWindow->viewport_GL )
+      {
+         consoleWindow->viewport_GL->setLinearFilterEnable( opt );
+      }
+   }
 }
 //----------------------------------------------------
 void ConsoleVideoConfDialog_t::use_new_PPU_changed( int value )

--- a/src/drivers/Qt/ConsoleVideoConf.h
+++ b/src/drivers/Qt/ConsoleVideoConf.h
@@ -46,6 +46,7 @@ class ConsoleVideoConfDialog_t : public QDialog
       void closeWindow(void);
 
 	private slots:
+		void  openGL_linearFilterChanged( int value );
 		void  use_new_PPU_changed( int value );
 		void  frameskip_changed( int value );
 		void  useSpriteLimitChanged( int value );

--- a/src/drivers/Qt/ConsoleViewerGL.cpp
+++ b/src/drivers/Qt/ConsoleViewerGL.cpp
@@ -9,6 +9,7 @@
 #include <QScreen>
 
 #include "Qt/nes_shm.h"
+#include "Qt/fceuWrapper.h"
 #include "Qt/ConsoleViewerGL.h"
 
 extern unsigned int gui_draw_area_width;
@@ -38,6 +39,14 @@ ConsoleViewGL_t::ConsoleViewGL_t(QWidget *parent)
 	{
 		memset( localBuf, 0, localBufSize );
 	}
+
+   if ( g_config )
+   {
+      int opt;
+      g_config->getOption("SDL.OpenGLip", &opt );
+
+      linearFilter = (opt) ? true : false;
+   }
 }
 
 ConsoleViewGL_t::~ConsoleViewGL_t(void)
@@ -118,6 +127,13 @@ void ConsoleViewGL_t::resizeGL(int w, int h)
 
 	gui_draw_area_width = w;
 	gui_draw_area_height = h;
+
+	buildTextures();
+}
+
+void ConsoleViewGL_t::setLinearFilterEnable( bool ena )
+{
+   linearFilter = ena;
 
 	buildTextures();
 }

--- a/src/drivers/Qt/ConsoleViewerGL.h
+++ b/src/drivers/Qt/ConsoleViewerGL.h
@@ -20,6 +20,8 @@ class ConsoleViewGL_t : public QOpenGLWidget, protected QOpenGLFunctions
 
 		void transfer2LocalBuffer(void);
 
+      void setLinearFilterEnable( bool ena );
+
 	protected:
    void initializeGL(void);
 	void resizeGL(int w, int h);

--- a/src/drivers/Qt/TraceLogger.cpp
+++ b/src/drivers/Qt/TraceLogger.cpp
@@ -1088,9 +1088,19 @@ void FCEUD_TraceInstruction(uint8 *opcode, int size)
 QTraceLogView::QTraceLogView(QWidget *parent)
 	: QWidget(parent)
 {
+   QPalette pal;
+	QColor fg("black"), bg("white");
+
 	font.setFamily("Courier New");
 	font.setStyle( QFont::StyleNormal );
 	font.setStyleHint( QFont::Monospace );
+
+   pal = this->palette();
+	pal.setColor(QPalette::Base      , bg );
+	pal.setColor(QPalette::Background, bg );
+	pal.setColor(QPalette::WindowText, fg );
+
+	this->setPalette(pal);
 
 	calcFontData();
 

--- a/src/drivers/Qt/config.cpp
+++ b/src/drivers/Qt/config.cpp
@@ -221,7 +221,7 @@ InitConfig()
 
 	// OpenGL options
 	config->addOption("opengl", "SDL.OpenGL", 1);
-	config->addOption("openglip", "SDL.OpenGLip", 1);
+	config->addOption("openglip", "SDL.OpenGLip", 0);
 	config->addOption("SDL.SpecialFilter", 0);
 	config->addOption("SDL.SpecialFX", 0);
 	config->addOption("SDL.Vsync", 1);

--- a/src/drivers/Qt/main.cpp
+++ b/src/drivers/Qt/main.cpp
@@ -1,3 +1,5 @@
+#include <stdio.h>
+#include <stdlib.h>
 #include <QApplication>
 
 #include "Qt/ConsoleWindow.h"
@@ -9,6 +11,27 @@ int main( int argc, char *argv[] )
 {
 	int retval;
 	QApplication app(argc, argv);
+   const char *styleSheetEnv = NULL;
+
+   styleSheetEnv = ::getenv("FCEUX_QT_STYLESHEET");
+
+   if ( styleSheetEnv != NULL )
+   {
+      QFile File(styleSheetEnv);
+
+      if ( File.open(QFile::ReadOnly) )
+      {
+         QString StyleSheet = QLatin1String(File.readAll());
+
+         app.setStyleSheet(StyleSheet);
+
+         printf("Using Qt Stylesheet file '%s'\n", styleSheetEnv );
+      }
+      else
+      {
+         printf("Warning: Could not open Qt Stylesheet file '%s'\n", styleSheetEnv );
+      }
+   }
 
 	fceuWrapperInit( argc, argv );
 


### PR DESCRIPTION
For the Qt GUI:
Hooked up OpenGL linear filtering functionality to video config checkbox.
Added custom gui styling option that allows the user to specify a Qt stylesheet file via an environment variable named FCEUX_QT_STYLESHEET. The application will now check for existance of this at start up.