### PR TITLE
SDL Minor Bug Fixes

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,9 +1,9 @@
-To compile and install FCEUX for SDL, follow the instructions in the README-SDL.md file.
+To compile and install FCEUX for SDL, follow the instructions in the README file.
 
 Users of Microsoft Visual Studio can use the solution files within the vc directory. The Windows XP toolset is required to open and build this solution. If it
 is not installed, go to "Tools" > "Get Tools and Features". Select "Individual Components" and then install "C++ Windows XP Support for VS 2017 (v141) tools".
 These solution files will compile FCEUX and some included libraries for full functionality.
 
 The SDL port build tool of choice has come full circle back to Cmake. The cmake build tool will compile the new Qt version of the SDL GUI.
-The scons build tool will build the older GTK based GUI which currently only builds on Linux. 
+Building of the SDL fceux no longer supports use of the scons build tool.
 

--- a/README
+++ b/README
@@ -7,7 +7,7 @@ Updated By mjbudd77
 
 http://www.fceux.com
 
-Last Modified: July 12, 2020
+Last Modified: October 21, 2020
 
 Table of Contents
 -----------------
@@ -22,7 +22,7 @@ Table of Contents
 
 1 - Requirements
 ----------------
-* sdl2  - Version >= 2.0
+* sdl2  - Version >= 2.0  (sdl2 >= 2.8 recommended)
 * cmake - Required to build fceux.
 * qt5 OR gtk3  - (qt version >= 5.11 recommended) (gtk3 >= 3.22 recommended)
 * liblua5.1 (optional) - Will statically link internally if the system cannot provide this.
@@ -37,15 +37,19 @@ The old scons build system is no longer supported.
 Fceux can be compiled and built using the cmake build system.  To compile, run:
 
 	mkdir build; cd build;
-   cmake  -DCMAKE_BUILD_TYPE=Release  ..    # For a release build
+   cmake  -DCMAKE_INSTALL_PREFIX=/usr  -DCMAKE_BUILD_TYPE=Release  ..    # For a release build
 
 To build a binary with debug information included in it:
-   cmake  -DCMAKE_BUILD_TYPE=Debug    ..    
+   cmake  -DCMAKE_INSTALL_PREFIX=/usr  -DCMAKE_BUILD_TYPE=Debug    ..    
 
 The Qt version of the GUI builds by default and this is the preferred GUI for use. 
 For those who must have GTK/Gnome style, 
 the GTK version of the GUI can be selected to build with:
-	cmake -DCMAKE_BUILD_TYPE=Release -DGTK=1 ..  # Release build using GTK GUI
+	cmake -DCMAKE_INSTALL_PREFIX=/usr  -DCMAKE_BUILD_TYPE=Release -DGTK=1 ..  # Release build using GTK GUI
+
+The Qt version GUI by far exceeds the GTK gui in capability and performance.
+I HIGHLY RECOMMEND USING THE Qt GUI instead of the GTK. See the TODO-SDL file for
+a capability matrix that compares what the two GUIs can do.
 
 To do the actual compiling:
    make
@@ -58,9 +62,8 @@ After a sucessful compilation, the fceux binary will be generated to
 
 	sudo make install
 
-You can optionally define a install prefix when running cmake from the previous step:
-
-	cmake -DCMAKE_INSTALL_PREFIX=/usr/local install
+By default cmake will use an installation prefix of /usr/local.
+The recommended installation prefix is /usr (this is where the installed fceux.desktop file expects everything to be)
 
 You can choose to install the lua scripts (located in output/luaScripts) to a directory of your choosing:
 
@@ -87,6 +90,13 @@ See above build instructions.
 OpenGL options:
 For Linux builds, the OpenGL library preference can be either GLVND or LEGACY (default). 
 To use GLVND OpenGL, add a -DGLVND=1 on the cmake command line.
+
+Qt Styling Options:
+The Qt GUI can use custom Qt widget styling by providing it a Qt stylesheet file. At startup, the GUI will look
+for an environment variable named FCEUX_QT_STYLESHEET that must contain the full path to the file. If the variable
+is defined and the file is readable by the program, then the styling settings will be used by the GUI.
+Bash Shell Setup Example:
+export FCEUX_QT_STYLESHEET=/home/me/myQt.stylesheet
 
 5 - LUA Scripting
 -----------------

--- a/TODO-SDL
+++ b/TODO-SDL
@@ -4,6 +4,8 @@ Priorities
    * GTK GUI was not cross-platform. A Qt5 version of the GUI has been created to meet this need. 
      I will keep the GTK GUI around for Linux users who prefer it, but when it comes to adding new features
      the Qt GUI is where I plan to add them first (if at all).
+   * The Qt GUI has by far exceeded the capabilities of the older GTK version. Below is a GUI capability 
+     matrix showing the differences between the two. I HIGHLY RECOMMEND USING THE Qt GUI.
    * Code cleanup. Lots of compiler warnings with newer GCC. Maybe I'm OCD... but these warnings bother me.
 
 Features

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,7 +81,7 @@ else(WIN32)
   pkg_check_modules( SDL2 REQUIRED sdl2)
 
   if ( ${SDL2_FOUND} )
-	  add_definitions( ${SDL2_CFLAGS} )
+	  add_definitions( ${SDL2_CFLAGS} -D__SDL__ )
   endif()
 
   # Check for LUA

--- a/src/drivers/Qt/AboutWindow.cpp
+++ b/src/drivers/Qt/AboutWindow.cpp
@@ -9,7 +9,6 @@
 #include <QUrl>
 #include <QTextEdit>
 #include <QDesktopServices>
-//#include "Qt/icon.xpm"
 #include "Qt/AboutWindow.h"
 #include "Qt/fceux_git_info.h"
 #include "../../version.h"
@@ -41,7 +40,6 @@ AboutWindow::AboutWindow(QWidget *parent)
 	int i;
 	QVBoxLayout *mainLayout;
 	QHBoxLayout *hbox1;
-	//QPixmap pm( icon_xpm );
 	QPixmap pm(":fceux1.png");
 	QPixmap pm2;
 	QLabel *lbl;

--- a/src/drivers/Qt/ConsoleDebugger.cpp
+++ b/src/drivers/Qt/ConsoleDebugger.cpp
@@ -3010,19 +3010,19 @@ void QAsmView::contextMenuEvent(QContextMenuEvent *event)
 
 		ctxMenuAddr = addr = asmEntry[line]->addr;
 
-		act = new QAction(tr("Add Breakpoint"), this);
+		act = new QAction(tr("Add Breakpoint"), &menu);
 		menu.addAction(act);
 		connect( act, SIGNAL(triggered(void)), parent, SLOT(asmViewCtxMenuAddBP(void)) );
 
-		act = new QAction(tr("Add Symbolic Debug Marker"), this);
+		act = new QAction(tr("Add Symbolic Debug Marker"), &menu);
 	 	menu.addAction(act);
 		connect( act, SIGNAL(triggered(void)), parent, SLOT(asmViewCtxMenuAddSym(void)) );
 
-		act = new QAction(tr("Add Bookmark"), this);
+		act = new QAction(tr("Add Bookmark"), &menu);
 	 	menu.addAction(act);
 		connect( act, SIGNAL(triggered(void)), parent, SLOT(asmViewCtxMenuAddBM(void)) );
 		
-		act = new QAction(tr("Open Hex Editor"), this);
+		act = new QAction(tr("Open Hex Editor"), &menu);
 	 	menu.addAction(act);
 		connect( act, SIGNAL(triggered(void)), parent, SLOT(asmViewCtxMenuOpenHexEdit(void)) );
 		
@@ -3294,7 +3294,7 @@ void DebuggerStackDisplay::contextMenuEvent(QContextMenuEvent *event)
    menu.addAction( act );
 
 	subMenu = menu.addMenu(tr("Display Bytes Per Line"));
-	group   = new QActionGroup(this);
+	group   = new QActionGroup(&menu);
 
 	group->setExclusive(true);
 

--- a/src/drivers/Qt/ConsoleVideoConf.cpp
+++ b/src/drivers/Qt/ConsoleVideoConf.cpp
@@ -179,6 +179,10 @@ void ConsoleVideoConfDialog_t::openGL_linearFilterChanged( int value )
       {
          consoleWindow->viewport_GL->setLinearFilterEnable( opt );
       }
+      if ( consoleWindow->viewport_SDL )
+      {
+         consoleWindow->viewport_SDL->setLinearFilterEnable( opt );
+      }
    }
 }
 //----------------------------------------------------

--- a/src/drivers/Qt/ConsoleViewerGL.cpp
+++ b/src/drivers/Qt/ConsoleViewerGL.cpp
@@ -133,9 +133,12 @@ void ConsoleViewGL_t::resizeGL(int w, int h)
 
 void ConsoleViewGL_t::setLinearFilterEnable( bool ena )
 {
-   linearFilter = ena;
+   if ( linearFilter != ena )
+   {
+      linearFilter = ena;
 
-	buildTextures();
+	   buildTextures();
+   }
 }
 
 void ConsoleViewGL_t::transfer2LocalBuffer(void)

--- a/src/drivers/Qt/ConsoleViewerGL.cpp
+++ b/src/drivers/Qt/ConsoleViewerGL.cpp
@@ -40,6 +40,8 @@ ConsoleViewGL_t::ConsoleViewGL_t(QWidget *parent)
 		memset( localBuf, 0, localBufSize );
 	}
 
+   linearFilter = false;
+
    if ( g_config )
    {
       int opt;

--- a/src/drivers/Qt/ConsoleViewerSDL.cpp
+++ b/src/drivers/Qt/ConsoleViewerSDL.cpp
@@ -7,6 +7,7 @@
 #include <unistd.h>
 
 #include "Qt/nes_shm.h"
+#include "Qt/fceuWrapper.h"
 #include "Qt/ConsoleViewerSDL.h"
 
 extern unsigned int gui_draw_area_width;
@@ -46,6 +47,13 @@ ConsoleViewSDL_t::ConsoleViewSDL_t(QWidget *parent)
 		memset( localBuf, 0, localBufSize );
 	}
 
+   if ( g_config )
+   {
+      int opt;
+      g_config->getOption("SDL.OpenGLip", &opt );
+
+      linearFilter = (opt) ? true : false;
+   }
 }
 
 ConsoleViewSDL_t::~ConsoleViewSDL_t(void)
@@ -56,6 +64,16 @@ ConsoleViewSDL_t::~ConsoleViewSDL_t(void)
 	}
 }
 
+void ConsoleViewSDL_t::setLinearFilterEnable( bool ena )
+{
+   if ( ena != linearFilter )
+   {
+      linearFilter = ena;
+
+	   reset();
+   }
+}
+
 void ConsoleViewSDL_t::transfer2LocalBuffer(void)
 {
 	memcpy( localBuf, nes_shm->pixbuf, localBufSize );
@@ -64,6 +82,15 @@ void ConsoleViewSDL_t::transfer2LocalBuffer(void)
 int ConsoleViewSDL_t::init(void)
 {
 	WId windowHandle;
+
+   if ( linearFilter )
+   {
+       SDL_SetHint( SDL_HINT_RENDER_SCALE_QUALITY, "1" );
+   }
+   else
+   {
+       SDL_SetHint( SDL_HINT_RENDER_SCALE_QUALITY, "0" );
+   }
 
 	if (SDL_InitSubSystem(SDL_INIT_VIDEO) != 0) 
 	{

--- a/src/drivers/Qt/ConsoleViewerSDL.cpp
+++ b/src/drivers/Qt/ConsoleViewerSDL.cpp
@@ -47,6 +47,8 @@ ConsoleViewSDL_t::ConsoleViewSDL_t(QWidget *parent)
 		memset( localBuf, 0, localBufSize );
 	}
 
+   linearFilter = false;
+
    if ( g_config )
    {
       int opt;

--- a/src/drivers/Qt/ConsoleViewerSDL.h
+++ b/src/drivers/Qt/ConsoleViewerSDL.h
@@ -23,6 +23,8 @@ class ConsoleViewSDL_t : public QWidget
 
 		void transfer2LocalBuffer(void);
 
+      void setLinearFilterEnable( bool ena );
+
 	protected:
 
 	//void paintEvent(QPaintEvent *event);
@@ -39,6 +41,7 @@ class ConsoleViewSDL_t : public QWidget
 	 int  sdlRendH;
 
 	 bool vsyncEnabled;
+    bool linearFilter;
 
 	 uint32_t  *localBuf;
 	uint32_t   localBufSize;

--- a/src/drivers/Qt/HexEditor.cpp
+++ b/src/drivers/Qt/HexEditor.cpp
@@ -1753,22 +1753,22 @@ void QHexEdit::contextMenuEvent(QContextMenuEvent *event)
 	{
 		case MODE_NES_RAM:
 		{
-			act = new QAction(tr("Add Symbolic Debug Name"), this);
+			act = new QAction(tr("Add Symbolic Debug Name"), &menu);
    		menu.addAction(act);
 			connect( act, SIGNAL(triggered(void)), this, SLOT(addDebugSym(void)) );
 
 			sprintf( stmp, "Add Read Breakpoint for Address $%04X", addr );
-			act = new QAction(tr(stmp), this);
+			act = new QAction(tr(stmp), &menu);
 			menu.addAction(act);
 			connect( act, SIGNAL(triggered(void)), this, SLOT(addRamReadBP(void)) );
 
 			sprintf( stmp, "Add Write Breakpoint for Address $%04X", addr );
-			act = new QAction(tr(stmp), this);
+			act = new QAction(tr(stmp), &menu);
 			menu.addAction(act);
 			connect( act, SIGNAL(triggered(void)), this, SLOT(addRamWriteBP(void)) );
 
 			sprintf( stmp, "Add Execute Breakpoint for Address $%04X", addr );
-			act = new QAction(tr(stmp), this);
+			act = new QAction(tr(stmp), &menu);
 			menu.addAction(act);
 			connect( act, SIGNAL(triggered(void)), this, SLOT(addRamExecuteBP(void)) );
 
@@ -1780,13 +1780,13 @@ void QHexEdit::contextMenuEvent(QContextMenuEvent *event)
 				{
 					jumpToRomValue = romAddr;
 					sprintf( stmp, "Go Here in ROM File: (%08X)", romAddr );
-					act = new QAction(tr(stmp), this);
+					act = new QAction(tr(stmp), &menu);
    				menu.addAction(act);
 					connect( act, SIGNAL(triggered(void)), this, SLOT(jumpToROM(void)) );
 				}
 			}
 
-			act = new QAction(tr("Add Bookmark"), this);
+			act = new QAction(tr("Add Bookmark"), &menu);
    		menu.addAction(act);
 			connect( act, SIGNAL(triggered(void)), this, SLOT(addBookMarkCB(void)) );
 		}
@@ -1794,30 +1794,30 @@ void QHexEdit::contextMenuEvent(QContextMenuEvent *event)
 		case MODE_NES_PPU:
 		{
 			sprintf( stmp, "Add Read Breakpoint for Address $%04X", addr );
-			act = new QAction(tr(stmp), this);
+			act = new QAction(tr(stmp), &menu);
 			menu.addAction(act);
 			connect( act, SIGNAL(triggered(void)), this, SLOT(addPpuReadBP(void)) );
 
 			sprintf( stmp, "Add Write Breakpoint for Address $%04X", addr );
-			act = new QAction(tr(stmp), this);
+			act = new QAction(tr(stmp), &menu);
 			menu.addAction(act);
 			connect( act, SIGNAL(triggered(void)), this, SLOT(addPpuWriteBP(void)) );
 
-			act = new QAction(tr("Add Bookmark"), this);
+			act = new QAction(tr("Add Bookmark"), &menu);
    		menu.addAction(act);
 			connect( act, SIGNAL(triggered(void)), this, SLOT(addBookMarkCB(void)) );
 		}
 		break;
 		case MODE_NES_OAM:
 		{
-			act = new QAction(tr("Add Bookmark"), this);
+			act = new QAction(tr("Add Bookmark"), &menu);
    		menu.addAction(act);
 			connect( act, SIGNAL(triggered(void)), this, SLOT(addBookMarkCB(void)) );
 		}
 		break;
 		case MODE_NES_ROM:
 		{
-			act = new QAction(tr("Add Bookmark"), this);
+			act = new QAction(tr("Add Bookmark"), &menu);
    		menu.addAction(act);
 			connect( act, SIGNAL(triggered(void)), this, SLOT(addBookMarkCB(void)) );
 		}

--- a/src/drivers/Qt/fceuWrapper.cpp
+++ b/src/drivers/Qt/fceuWrapper.cpp
@@ -209,7 +209,8 @@ DriverKill()
 /**
  * Reloads last game
  */
-int reloadLastGame() {
+int reloadLastGame(void)
+{
 	std::string lastRom;
 	g_config->getOption(std::string("SDL.LastOpenFile"), &lastRom);
 	return LoadGame(lastRom.c_str(), false);

--- a/src/drivers/Qt/fceuWrapper.h
+++ b/src/drivers/Qt/fceuWrapper.h
@@ -21,6 +21,7 @@ extern Config *g_config;
 
 int LoadGame(const char *path, bool silent = false);
 int CloseGame(void);
+int reloadLastGame(void);
 
 int  fceuWrapperInit( int argc, char *argv[] );
 int  fceuWrapperClose( void );

--- a/src/drivers/Qt/ppuViewer.cpp
+++ b/src/drivers/Qt/ppuViewer.cpp
@@ -417,7 +417,7 @@ void ppuPatternView_t::contextMenuEvent(QContextMenuEvent *event)
    menu.addAction( act );
 
 	subMenu = menu.addMenu(tr("Palette Select"));
-	group   = new QActionGroup(this);
+	group   = new QActionGroup(&menu);
 
 	group->setExclusive(true);
 

--- a/src/drivers/Qt/ppuViewer.cpp
+++ b/src/drivers/Qt/ppuViewer.cpp
@@ -390,12 +390,14 @@ void ppuPatternView_t::contextMenuEvent(QContextMenuEvent *event)
       sprintf( stmp, "Exit Tile View: %X%X", selTile.y(), selTile.x() );
 
       act = new QAction(tr(stmp), &menu);
+      act->setShortcut( QKeySequence(tr("Z")));
 	   connect( act, SIGNAL(triggered(void)), this, SLOT(exitTileMode(void)) );
       menu.addAction( act );
 
       act = new QAction(tr("Draw Tile Grid Lines"), &menu);
       act->setCheckable(true);
       act->setChecked(drawTileGrid);
+      act->setShortcut( QKeySequence(tr("G")));
 	   connect( act, SIGNAL(triggered(void)), this, SLOT(toggleTileGridLines(void)) );
       menu.addAction( act );
    }
@@ -404,10 +406,15 @@ void ppuPatternView_t::contextMenuEvent(QContextMenuEvent *event)
       sprintf( stmp, "View Tile: %X%X", selTile.y(), selTile.x() );
 
       act = new QAction(tr(stmp), &menu);
+      act->setShortcut( QKeySequence(tr("Z")));
 	   connect( act, SIGNAL(triggered(void)), this, SLOT(showTileMode(void)) );
       menu.addAction( act );
    }
 
+   act = new QAction(tr("Next Palette"), &menu);
+   act->setShortcut( QKeySequence(tr("P")));
+	connect( act, SIGNAL(triggered(void)), this, SLOT(cycleNextPalette(void)) );
+   menu.addAction( act );
 
 	subMenu = menu.addMenu(tr("Palette Select"));
 	group   = new QActionGroup(this);
@@ -455,6 +462,15 @@ void ppuPatternView_t::showTileMode(void)
 void ppuPatternView_t::exitTileMode(void)
 {
    mode = 0;
+}
+//----------------------------------------------------
+void ppuPatternView_t::cycleNextPalette(void)
+{
+   pindex[ patternIndex ] = (pindex[ patternIndex ] + 1) % 9;
+
+	PPUViewSkip = 100;
+
+	FCEUD_UpdatePPUView( -1, 0 );
 }
 //----------------------------------------------------
 void ppuPatternView_t::selPalette0(void)

--- a/src/drivers/Qt/ppuViewer.h
+++ b/src/drivers/Qt/ppuViewer.h
@@ -77,6 +77,7 @@ class ppuPatternView_t : public QWidget
       void selPalette6(void);
       void selPalette7(void);
       void selPalette8(void);
+      void cycleNextPalette(void);
       void toggleTileGridLines(void);
 };
 

--- a/src/drivers/Qt/sdl-throttle.cpp
+++ b/src/drivers/Qt/sdl-throttle.cpp
@@ -143,13 +143,13 @@ int CustomEmulationSpeed(int spdPercent)
 	g_fpsScale = ((double)spdPercent) / 100.0f;
 
 	if (g_fpsScale < Slowest)
-   {
-	   g_fpsScale = Slowest;
-   }
-   else if (g_fpsScale > Fastest)
-   {
-	   g_fpsScale = Fastest;
-   }
+	{
+		g_fpsScale = Slowest;
+	}
+	else if (g_fpsScale > Fastest)
+	{
+		g_fpsScale = Fastest;
+	}
 
 	RefreshThrottleFPS();
 

--- a/src/drivers/Qt/sdl-video.cpp
+++ b/src/drivers/Qt/sdl-video.cpp
@@ -30,7 +30,6 @@
 
 #include "utils/memory.h"
 
-//#include "sdl-icon.h"
 #include "Qt/dface.h"
 
 #include "common/configSys.h"

--- a/src/lua-engine.cpp
+++ b/src/lua-engine.cpp
@@ -6,7 +6,9 @@
 #include <sys/wait.h>
 #include <libgen.h>
 #elif   __APPLE__
+#include <stdlib.h>
 #include <libgen.h>
+#include <mach-o/dyld.h>
 #endif
 
 #ifdef WIN32

--- a/src/lua-engine.cpp
+++ b/src/lua-engine.cpp
@@ -42,6 +42,17 @@ extern char FileBase[];
 extern TASEDITOR_LUA taseditor_lua;
 #endif
 
+#ifdef __SDL__
+
+#ifdef __QT_DRIVER__
+#include "drivers/Qt/fceuWrapper.h"
+#else
+int LoadGame(const char *path, bool silent = false);
+int reloadLastGame(void);
+#endif
+
+#endif
+
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -520,13 +531,14 @@ static int emu_getdir(lua_State *L) {
 
 
 extern void ReloadRom(void);
-extern int LoadGame(const char*, bool);
+
 
 // emu.loadrom(string filename)
 //
 //  Loads the rom from the directory relative to the lua script or from the absolute path.
 //  If the rom can't be loaded, loads the most recent one.
-static int emu_loadrom(lua_State *L) {
+static int emu_loadrom(lua_State *L) 
+{
 #ifdef WIN32
 	const char* str = lua_tostring(L,1);
 
@@ -550,8 +562,8 @@ static int emu_loadrom(lua_State *L) {
 	const char *nameo2 = luaL_checkstring(L,1);
 	char nameo[2048];
 	strncpy(nameo, nameo2, sizeof(nameo));
-	if(!LoadGame(nameo, true)) {
-		extern void reloadLastGame();
+	if (!LoadGame(nameo, true)) 
+	{
 		reloadLastGame();
 		return 0;
 	} else {

--- a/src/lua-engine.cpp
+++ b/src/lua-engine.cpp
@@ -5,6 +5,8 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <libgen.h>
+#elif   __APPLE__
+#include <libgen.h>
 #endif
 
 #ifdef WIN32
@@ -553,23 +555,16 @@ static int emu_getdir(lua_State *L) {
 
 	if ( result == 0 )
 	{
-		int i = bufSize;
+		char *dir;
 		exePath[ bufSize ] = 0;
 		//printf("EXE Path: '%s' \n", exePath );
 
-		while ( i >= 0 )
-		{
-			if ( exePath[i] == '/' )
-			{
-				break;
-			}
-			exePath[i] = 0; i--;
-		}
+		dir = ::dirname( exePath );
 
-		if ( i > 0 )
+		if ( dir )
 		{
-			//printf("DIR Path: '%s' \n", exePath );
-	  		lua_pushstring(L, exePath);
+			//printf("DIR Path: '%s' \n", dir );
+			lua_pushstring(L, dir);
 			return 1;
 		}
 	}
@@ -6083,7 +6078,8 @@ static const struct luaL_reg cdloglib[] = {
 	{ NULL,NULL }
 };
 
-void CallExitFunction() {
+void CallExitFunction() 
+{
 	if (!L)
 		return;
 


### PR DESCRIPTION
1. Fix to ensure that Qt context menu child widgets all have their parent widget set correctly so that they are destroyed when the menu goes out of scope.
2. Fixed SDL functionaltiy for lua emu.loadrom and emu.getdir functions. This fixes issue #195 
3. Updated SDL build/install instructions to use recommended /usr installation path prefix instead of the cmake default /usr/local.   This fixes at least part of issue #196 