### PR TITLE
For Qt, added logic to allow for auto video scaling on window resize …

### DIFF
--- a/src/drivers/Qt/ConsoleVideoConf.cpp
+++ b/src/drivers/Qt/ConsoleVideoConf.cpp
@@ -85,6 +85,9 @@ ConsoleVideoConfDialog_t::ConsoleVideoConfDialog_t(QWidget *parent)
 	// Show FPS Checkbox
 	showFPS_cbx  = new QCheckBox( tr("Show FPS") );
 
+	// Auto Scale on Resize
+	autoScaleCbx  = new QCheckBox( tr("Auto Scale on Resize") );
+
 	// Square Pixels
 	sqrPixCbx  = new QCheckBox( tr("Square Pixels") );
 
@@ -98,10 +101,12 @@ ConsoleVideoConfDialog_t::ConsoleVideoConfDialog_t(QWidget *parent)
 	{
 		if ( consoleWindow->viewport_GL )
 		{
+			autoScaleCbx->setChecked( consoleWindow->viewport_GL->getAutoScaleOpt() );
 			sqrPixCbx->setChecked( consoleWindow->viewport_GL->getSqrPixelOpt() );
 		}
 		else if ( consoleWindow->viewport_SDL )
 		{
+			autoScaleCbx->setChecked( consoleWindow->viewport_SDL->getAutoScaleOpt() );
 			sqrPixCbx->setChecked( consoleWindow->viewport_SDL->getSqrPixelOpt() );
 		}
 	}
@@ -118,7 +123,8 @@ ConsoleVideoConfDialog_t::ConsoleVideoConfDialog_t(QWidget *parent)
 	main_vbox->addWidget( sprtLimCbx  );
 	main_vbox->addWidget( clipSidesCbx);
 	main_vbox->addWidget( showFPS_cbx );
-	main_vbox->addWidget( sqrPixCbx );
+	main_vbox->addWidget( autoScaleCbx);
+	main_vbox->addWidget( sqrPixCbx   );
 
 	xScaleBox = new QDoubleSpinBox(this);
 	yScaleBox = new QDoubleSpinBox(this);
@@ -411,15 +417,30 @@ void ConsoleVideoConfDialog_t::applyChanges( void )
 
 	if ( consoleWindow )
 	{
+		float xscale, yscale;
 		QSize s = calcNewScreenSize();
+
+		if ( sqrPixCbx->isChecked() )
+		{
+			yscale = xscale = xScaleBox->value();
+		}
+		else
+		{
+			xscale = xScaleBox->value();
+			yscale = yScaleBox->value();
+		}
 
 		if ( consoleWindow->viewport_GL )
 		{
 		   consoleWindow->viewport_GL->setSqrPixelOpt( sqrPixCbx->isChecked() );
+		   consoleWindow->viewport_GL->setAutoScaleOpt( autoScaleCbx->isChecked() );
+		   consoleWindow->viewport_GL->setScaleXY( xscale, yscale );
 		}
 		if ( consoleWindow->viewport_SDL )
 		{
 		   consoleWindow->viewport_SDL->setSqrPixelOpt( sqrPixCbx->isChecked() );
+		   consoleWindow->viewport_SDL->setAutoScaleOpt( autoScaleCbx->isChecked() );
+		   consoleWindow->viewport_SDL->setScaleXY( xscale, yscale );
 		}
 
 		consoleWindow->resize( s );

--- a/src/drivers/Qt/ConsoleVideoConf.h
+++ b/src/drivers/Qt/ConsoleVideoConf.h
@@ -36,6 +36,7 @@ class ConsoleVideoConfDialog_t : public QDialog
 		QCheckBox   *sprtLimCbx;
 		QCheckBox   *clipSidesCbx;
 		QCheckBox   *showFPS_cbx;
+		QCheckBox   *autoScaleCbx;
 		QCheckBox   *sqrPixCbx;
 		QDoubleSpinBox *xScaleBox;
 		QDoubleSpinBox *yScaleBox;

--- a/src/drivers/Qt/ConsoleViewerGL.h
+++ b/src/drivers/Qt/ConsoleViewerGL.h
@@ -24,8 +24,11 @@ class ConsoleViewGL_t : public QOpenGLWidget, protected QOpenGLFunctions
 
 		bool   getSqrPixelOpt(void){ return sqrPixels; };
 		void   setSqrPixelOpt( bool val ){ sqrPixels = val; return; };
+		bool   getAutoScaleOpt(void){ return autoScaleEna; };
+		void   setAutoScaleOpt( bool val ){ autoScaleEna = val; return; };
 		double getScaleX(void){ return xscale; };
 		double getScaleY(void){ return yscale; };
+		void   setScaleXY( double xs, double ys );
 
 	protected:
    void initializeGL(void);
@@ -44,6 +47,7 @@ class ConsoleViewGL_t : public QOpenGLWidget, protected QOpenGLFunctions
 	GLuint gltexture;
 	bool   linearFilter;
 	bool   sqrPixels;
+	bool   autoScaleEna;
 
 	uint32_t  *localBuf;
 	uint32_t   localBufSize;

--- a/src/drivers/Qt/ConsoleViewerSDL.cpp
+++ b/src/drivers/Qt/ConsoleViewerSDL.cpp
@@ -53,15 +53,16 @@ ConsoleViewSDL_t::ConsoleViewSDL_t(QWidget *parent)
 	}
 
 	sqrPixels = true;
-   linearFilter = false;
+	autoScaleEna = true;
+	linearFilter = false;
 
-   if ( g_config )
-   {
-      int opt;
-      g_config->getOption("SDL.OpenGLip", &opt );
-
-      linearFilter = (opt) ? true : false;
-   }
+	if ( g_config )
+	{
+		int opt;
+		g_config->getOption("SDL.OpenGLip", &opt );
+		
+		linearFilter = (opt) ? true : false;
+	}
 }
 
 ConsoleViewSDL_t::~ConsoleViewSDL_t(void)
@@ -80,6 +81,24 @@ void ConsoleViewSDL_t::setLinearFilterEnable( bool ena )
 
 	   reset();
    }
+}
+
+void ConsoleViewSDL_t::setScaleXY( double xs, double ys )
+{
+	xscale = xs;
+	yscale = ys;
+
+	if ( sqrPixels )
+	{
+		if (xscale < yscale )
+		{
+			yscale = xscale;
+		}
+		else 
+		{
+			xscale = yscale;
+		}
+	}
 }
 
 void ConsoleViewSDL_t::transfer2LocalBuffer(void)
@@ -219,25 +238,40 @@ void ConsoleViewSDL_t::render(void)
 		nesHeight = nes_shm->nrow;
 	}
 	//printf(" %i x %i \n", nesWidth, nesHeight );
-	xscale = (float)view_width  / (float)nesWidth;
-	yscale = (float)view_height / (float)nesHeight;
+	float xscaleTmp = (float)view_width  / (float)nesWidth;
+	float yscaleTmp = (float)view_height / (float)nesHeight;
 
 	if ( sqrPixels )
 	{
-		if (xscale < yscale )
+		if (xscaleTmp < yscaleTmp )
 		{
-			yscale = xscale;
+			yscaleTmp = xscaleTmp;
 		}
 		else 
 		{
-			xscale = yscale;
+			xscaleTmp = yscaleTmp;
 		}
 	}
 
-	rw=(int)(nesWidth*xscale);
-	rh=(int)(nesHeight*yscale);
-	//sx=sdlViewport.x + (view_width-rw)/2;   
-	//sy=sdlViewport.y + (view_height-rh)/2;
+	if ( autoScaleEna )
+	{
+		xscale = xscaleTmp;
+		yscale = yscaleTmp;
+	}
+	else
+	{
+		if ( xscaleTmp > xscale )
+		{
+			xscaleTmp = xscale;
+		}
+		if ( yscaleTmp > yscale )
+		{
+			yscaleTmp = yscale;
+		}
+	}
+
+	rw=(int)(nesWidth*xscaleTmp);
+	rh=(int)(nesHeight*yscaleTmp);
 	sx=(view_width-rw)/2;   
 	sy=(view_height-rh)/2;
 

--- a/src/drivers/Qt/ConsoleViewerSDL.h
+++ b/src/drivers/Qt/ConsoleViewerSDL.h
@@ -27,8 +27,11 @@ class ConsoleViewSDL_t : public QWidget
 
 		bool   getSqrPixelOpt(void){ return sqrPixels; };
 		void   setSqrPixelOpt( bool val ){ sqrPixels = val; return; };
+		bool   getAutoScaleOpt(void){ return autoScaleEna; };
+		void   setAutoScaleOpt( bool val ){ autoScaleEna = val; return; };
 		double getScaleX(void){ return xscale; };
 		double getScaleY(void){ return yscale; };
+		void   setScaleXY( double xs, double ys );
 
 	protected:
 
@@ -50,6 +53,7 @@ class ConsoleViewSDL_t : public QWidget
 	bool vsyncEnabled;
 	bool linearFilter;
 	bool sqrPixels;
+	bool autoScaleEna;
 
 	uint32_t  *localBuf;
 	uint32_t   localBufSize;


### PR DESCRIPTION
…to be optional. An 'Auto scale on resize' checkbox has been added to the video config window. When this box is checked (and applied) the window will always auto rescale the video image to a best fit on a resize. If not checked, window will use the specified numerical scale values as a maximum scaling limit. This means that the window will allow scaling the image down if the window is not large enough to fit image at the requested scale, but will never scale the image up past the request scale. So if the window is at a large size and the requested scale is small, the result will be a small video image on a big window with a lot of black space. This is for issue #205.