### PR TITLE
emu.loadrom: return path of loaded rom

### DIFF
--- a/src/drivers/Qt/fceuWrapper.cpp
+++ b/src/drivers/Qt/fceuWrapper.cpp
@@ -207,16 +207,6 @@ DriverKill()
 }
 
 /**
- * Reloads last game
- */
-int reloadLastGame(void)
-{
-	std::string lastRom;
-	g_config->getOption(std::string("SDL.LastOpenFile"), &lastRom);
-	return LoadGame(lastRom.c_str(), false);
-}
-
-/**
  * Loads a game, given a full path/filename.  The driver code must be
  * initialized after the game is loaded, because the emulator code
  * provides data necessary for the driver code(number of scanlines to

--- a/src/drivers/Qt/fceuWrapper.cpp
+++ b/src/drivers/Qt/fceuWrapper.cpp
@@ -57,9 +57,6 @@ bool turbo = false;
 unsigned int gui_draw_area_width   = 256;
 unsigned int gui_draw_area_height  = 256;
 
-// global configuration object
-Config *g_config = NULL;
-
 static int inited = 0;
 static int noconfig=0;
 static int frameskip=0;

--- a/src/drivers/Qt/fceuWrapper.h
+++ b/src/drivers/Qt/fceuWrapper.h
@@ -21,7 +21,6 @@ extern Config *g_config;
 
 int LoadGame(const char *path, bool silent = false);
 int CloseGame(void);
-int reloadLastGame(void);
 
 int  fceuWrapperInit( int argc, char *argv[] );
 int  fceuWrapperClose( void );

--- a/src/drivers/common/configSys.cpp
+++ b/src/drivers/common/configSys.cpp
@@ -745,3 +745,5 @@ Config::save()
 
 	return 0;
 }
+
+Config* g_config = nullptr;

--- a/src/drivers/common/configSys.cpp
+++ b/src/drivers/common/configSys.cpp
@@ -747,3 +747,12 @@ Config::save()
 }
 
 Config* g_config = nullptr;
+
+int LoadGame(const char *path, bool silent); // defined differently in Qt vs SDL code
+
+int reloadLastGame()
+{
+	std::string lastRom;
+	g_config->getOption("SDL.LastOpenFile", &lastRom);
+	return LoadGame(lastRom.c_str(), false);
+}

--- a/src/drivers/common/configSys.cpp
+++ b/src/drivers/common/configSys.cpp
@@ -750,9 +750,9 @@ Config* g_config = nullptr;
 
 int LoadGame(const char *path, bool silent); // defined differently in Qt vs SDL code
 
-int reloadLastGame()
+std::pair<int, std::string> reloadLastGame()
 {
 	std::string lastRom;
 	g_config->getOption("SDL.LastOpenFile", &lastRom);
-	return LoadGame(lastRom.c_str(), false);
+	return {LoadGame(lastRom.c_str(), false), lastRom};
 }

--- a/src/drivers/common/configSys.h
+++ b/src/drivers/common/configSys.h
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <string>
+#include <tuple>
 
 class Config {
 private:
@@ -95,8 +96,9 @@ public:
 extern Config* g_config;
 
 /**
- * Reloads last game
+ * Reloads last game. Result is a pair of error code and the file that we attempted to load. Code 1 means success, 0
+ * failure.
  */
-int reloadLastGame();
+std::pair<int, std::string> reloadLastGame();
 
 #endif // !__CONFIGSYS_H

--- a/src/drivers/common/configSys.h
+++ b/src/drivers/common/configSys.h
@@ -91,4 +91,7 @@ public:
     int save();
 };
 
+// Global configuration object
+extern Config* g_config;
+
 #endif // !__CONFIGSYS_H

--- a/src/drivers/common/configSys.h
+++ b/src/drivers/common/configSys.h
@@ -94,4 +94,9 @@ public:
 // Global configuration object
 extern Config* g_config;
 
+/**
+ * Reloads last game
+ */
+int reloadLastGame();
+
 #endif // !__CONFIGSYS_H

--- a/src/drivers/sdl/sdl.cpp
+++ b/src/drivers/sdl/sdl.cpp
@@ -161,9 +161,6 @@ static const char *DriverUsage=
 //--slstart	{0-239}   Sets the first drawn emulated scanline.\n
 //--clipsides	{0|1}   Clips left and rightmost 8 columns of pixels.\n
 
-// global configuration object
-Config *g_config;
-
 static void ShowUsage(char *prog)
 {
 	printf("\nUsage is as follows:\n%s <options> filename\n\n",prog);

--- a/src/drivers/sdl/sdl.cpp
+++ b/src/drivers/sdl/sdl.cpp
@@ -187,15 +187,6 @@ static void ShowUsage(char *prog)
 }
 
 /**
- * Reloads last game.
- */
-int reloadLastGame() {
-	std::string lastRom;
-	g_config->getOption(std::string("SDL.LastOpenFile"), &lastRom);
-	return LoadGame(lastRom.c_str());
-}
-
-/**
  * Loads a game, given a full path/filename.  The driver code must be
  * initialized after the game is loaded, because the emulator code
  * provides data necessary for the driver code(number of scanlines to

--- a/src/drivers/win/window.cpp
+++ b/src/drivers/win/window.cpp
@@ -761,7 +761,7 @@ void AddRecentFile(const char *filename)
 	UpdateRecentArray(filename, recent_files, MAX_NUMBER_OF_RECENT_FILES, recentmenu, MENU_RECENT_FILES, MENU_FIRST_RECENT_FILE);
 }
 
-void LoadRecentRom(int slot)
+char* LoadRecentRom(int slot)
 {
 	char*& fname = recent_files[slot];
 	if(fname)
@@ -775,7 +775,13 @@ void LoadRecentRom(int slot)
 				UpdateRMenu(recentmenu, recent_files, MENU_RECENT_FILES, MENU_FIRST_RECENT_FILE);
 			}
 		}
+		else
+		{
+			return fname;
+		}
 	}
+
+	return nullptr;
 }
 
 void UpdateLuaRMenu(HMENU menu, char **strs, unsigned int mitem, unsigned int baseid)

--- a/src/drivers/win/window.h
+++ b/src/drivers/win/window.h
@@ -31,6 +31,7 @@ void DoTimingConfigFix();
 int CreateMainWindow();
 void UpdateCheckedMenuItems();
 void LoadNewGamey(HWND hParent, const char *initialdir);
+// Returns nullptr on failure.
 char* LoadRecentRom(int slot);
 int BrowseForFolder(HWND hParent, const char *htext, char *buf);
 void SetMainWindowStuff();

--- a/src/drivers/win/window.h
+++ b/src/drivers/win/window.h
@@ -33,6 +33,7 @@ void DoTimingConfigFix();
 int CreateMainWindow();
 void UpdateCheckedMenuItems();
 void LoadNewGamey(HWND hParent, const char *initialdir);
+char* LoadRecentRom(int slot);
 int BrowseForFolder(HWND hParent, const char *htext, char *buf);
 void SetMainWindowStuff();
 void GetMouseData(uint32 (&md)[3]);

--- a/src/drivers/win/window.h
+++ b/src/drivers/win/window.h
@@ -4,8 +4,6 @@
 #include "common.h"
 #include <string>
 
-using namespace std;
-
 // Type definitions
 
 struct CreateMovieParameters
@@ -38,7 +36,7 @@ int BrowseForFolder(HWND hParent, const char *htext, char *buf);
 void SetMainWindowStuff();
 void GetMouseData(uint32 (&md)[3]);
 void GetMouseRelative(int32 (&md)[3]);
-//void ChangeMenuItemText(int menuitem, string text);
+//void ChangeMenuItemText(int menuitem, std::string text);
 POINT CalcSubWindowPos(HWND hDlg, POINT* conf);
 
 template<int BUFSIZE>

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1302,7 +1302,6 @@ void ReloadRom(void)
 	} else
 	{
 		// load most recent ROM
-		extern void LoadRecentRom(int slot);
 		LoadRecentRom(0);
 	}
 #endif

--- a/src/lua-engine.cpp
+++ b/src/lua-engine.cpp
@@ -41,6 +41,7 @@ extern char FileBase[];
 #ifdef WIN32
 #include "drivers/win/common.h"
 #include "drivers/win/main.h"
+#include "drivers/win/window.h"
 #include "drivers/win/taseditor/selection.h"
 #include "drivers/win/taseditor/laglog.h"
 #include "drivers/win/taseditor/markers.h"
@@ -609,7 +610,6 @@ static int emu_loadrom(lua_State *L)
 	char nameo[2048];
 	strncpy(nameo, nameo2, sizeof(nameo));
 	if (!ALoad(nameo)) {
-		extern void LoadRecentRom(int slot);
 		LoadRecentRom(0);
 		return 0;
 	} else {

--- a/src/lua-engine.cpp
+++ b/src/lua-engine.cpp
@@ -57,7 +57,6 @@ extern TASEDITOR_LUA taseditor_lua;
 #include "drivers/Qt/fceuWrapper.h"
 #else
 int LoadGame(const char *path, bool silent = false);
-int reloadLastGame(void);
 #endif
 
 #endif

--- a/web/help/LuaFunctionsList.html
+++ b/web/help/LuaFunctionsList.html
@@ -159,6 +159,8 @@
 <p><span class="rvts78">Loads the ROM from the directory relative to the lua script or from the absolute path. Hence, the filename parameter can be absolute or relative path.</span></p>
 <p><span class="rvts78"><br/></span></p>
 <p><span class="rvts78">If the ROM can't be loaded, loads the most recent one.</span></p>
+<p><span class="rvts78"><br/></span></p>
+<p><span class="rvts78">Returns the filename of the loaded rom, or nil if loading failed.</span></p>
 <p><span class="rvts37"><br/></span></p>
 <p><span class="rvts63">emu.registerbefore(function func)</span></p>
 <p><span class="rvts37"><br/></span></p>


### PR DESCRIPTION
there should be a programmatic way to check that:
- the ROM requested was the one actually loaded
- something was loaded successfully

this PR accomplishes that by adding a return value for emu.loadrom. for a successful load, it is a string holding the
path of the ROM just loaded. for a load fail, it is nil.

i'm not sure the best way to handle the ReloadRom path on Windows, because it goes into taseditor code. so right now
that path returns empty string. it also seems like a bug that there isn't a similar path for the non-Windows branch of
emu_loadrom.

as a result of this change a couple functions moved location. i didn't see a more appropriate header in drivers/common
to place these, but i can make one if you'd like.