### PR TITLE
Bug fix for issue #217. The Qt hex editor memory reads are now synchr…

### DIFF
--- a/src/drivers/Qt/ConsoleDebugger.cpp
+++ b/src/drivers/Qt/ConsoleDebugger.cpp
@@ -1427,9 +1427,9 @@ void ConsoleDebugger::reloadSymbolsCB(void)
 {
 	fceuWrapperLock();
 	debugSymbolTable.loadGameSymbols();
-	fceuWrapperUnLock();
 
 	asmView->updateAssemblyView();
+	fceuWrapperUnLock();
 }
 //----------------------------------------------------------------------------
 void ConsoleDebugger::debugRunCB(void)
@@ -2812,7 +2812,9 @@ void QAsmView::setDisplayROMoffsets( bool value )
 	{
 		displayROMoffsets = value;
 
+		fceuWrapperLock();
 		updateAssemblyView();
+		fceuWrapperUnLock();
 	}
 }
 //----------------------------------------------------------------------------
@@ -2822,7 +2824,9 @@ void QAsmView::setSymbolDebugEnable( bool value )
 	{
 		symbolicDebugEnable = value;
 
+		fceuWrapperLock();
 		updateAssemblyView();
+		fceuWrapperUnLock();
 	}
 }
 //----------------------------------------------------------------------------
@@ -2832,7 +2836,9 @@ void QAsmView::setRegisterNameEnable( bool value )
 	{
 		registerNameEnable = value;
 
+		fceuWrapperLock();
 		updateAssemblyView();
+		fceuWrapperUnLock();
 	}
 }
 //----------------------------------------------------------------------------

--- a/src/drivers/Qt/HexEditor.h
+++ b/src/drivers/Qt/HexEditor.h
@@ -248,6 +248,7 @@ class HexEditorDialog_t : public QDialog
 };
 
 int hexEditorNumWindows(void);
+void hexEditorUpdateMemoryValues(void);
 void hexEditorLoadBookmarks(void);
 void hexEditorSaveBookmarks(void);
 int hexEditorOpenFromDebugger( int mode, int addr );

--- a/src/drivers/Qt/fceuWrapper.cpp
+++ b/src/drivers/Qt/fceuWrapper.cpp
@@ -1043,6 +1043,8 @@ int  fceuWrapperUpdate( void )
 	{
 		DoFun(frameskip, periodic_saves);
 	
+		hexEditorUpdateMemoryValues();
+
 		fceuWrapperUnLock();
 
 		emulatorHasMutux = 0;


### PR DESCRIPTION
…onized with emulation thread execution. This ensures that calls to GetMem will not improperly interfere with certain memory mapped registers while the emulation thread is executing. Reading at an inappropriate time from controller registers mapped at addresses $4016 and $4017 can cause the emulator to miss button presses. Thread synchronization fixes this.