### PR TITLE
Qt Debugger Window Enhancements

### DIFF
--- a/src/drivers/Qt/ConsoleDebugger.h
+++ b/src/drivers/Qt/ConsoleDebugger.h
@@ -114,6 +114,7 @@ class QAsmView : public QWidget
 		int  getCtxMenuAddr(void){ return ctxMenuAddr; };
 		int  getCursorAddr(void){ return cursorLineAddr; };
 		void setPC_placement( int mode, int ofs = 0 );
+		void setBreakpointAtSelectedLine(void);
 	protected:
 		void paintEvent(QPaintEvent *event);
 		void keyPressEvent(QKeyEvent *event);

--- a/src/drivers/Qt/ConsoleDebugger.h
+++ b/src/drivers/Qt/ConsoleDebugger.h
@@ -291,6 +291,7 @@ class ConsoleDebugger : public QDialog
 		void asmViewCtxMenuAddBM(void);
 		void asmViewCtxMenuAddSym(void);
 		void asmViewCtxMenuOpenHexEdit(void);
+		void asmViewCtxMenuRunToCursor(void);
 	private slots:
 		void updatePeriodic(void);
 		void hbarChanged(int value);

--- a/src/drivers/Qt/ConsoleDebugger.h
+++ b/src/drivers/Qt/ConsoleDebugger.h
@@ -112,6 +112,7 @@ class QAsmView : public QWidget
 		void setSymbolDebugEnable( bool value );
 		void setRegisterNameEnable( bool value );
 		int  getCtxMenuAddr(void){ return ctxMenuAddr; };
+		void setPC_placement( int mode, int ofs = 0 );
 	protected:
 		void paintEvent(QPaintEvent *event);
 		void keyPressEvent(QKeyEvent *event);
@@ -154,6 +155,8 @@ class QAsmView : public QWidget
 		int pxLineXScroll;
 		int cursorPosX;
 		int cursorPosY;
+		int pcLinePlacement;
+		int pcLineOffset;
 
 		int  selAddrLine;
 		int  selAddrChar;
@@ -178,6 +181,7 @@ class QAsmView : public QWidget
 		bool  symbolicDebugEnable;
 		bool  registerNameEnable;
 		bool  mouseLeftBtnDown;
+
 };
 
 class DebuggerStackDisplay : public QPlainTextEdit
@@ -326,6 +330,12 @@ class ConsoleDebugger : public QDialog
 		void cpuCycleThresChanged(const QString &txt);
 		void instructionsThresChanged(const QString &txt);
 		void selBmAddrChanged(const QString &txt);
+		void pcSetPlaceTop(void);
+		void pcSetPlaceUpperMid(void);
+		void pcSetPlaceCenter(void);
+		void pcSetPlaceLowerMid(void);
+		void pcSetPlaceBottom(void);
+		void pcSetPlaceCustom(void);
 
 };
 

--- a/src/drivers/Qt/ConsoleDebugger.h
+++ b/src/drivers/Qt/ConsoleDebugger.h
@@ -112,6 +112,7 @@ class QAsmView : public QWidget
 		void setSymbolDebugEnable( bool value );
 		void setRegisterNameEnable( bool value );
 		int  getCtxMenuAddr(void){ return ctxMenuAddr; };
+		int  getCursorAddr(void){ return cursorLineAddr; };
 		void setPC_placement( int mode, int ofs = 0 );
 	protected:
 		void paintEvent(QPaintEvent *event);
@@ -155,6 +156,7 @@ class QAsmView : public QWidget
 		int pxLineXScroll;
 		int cursorPosX;
 		int cursorPosY;
+		int cursorLineAddr;
 		int pcLinePlacement;
 		int pcLineOffset;
 
@@ -304,6 +306,7 @@ class ConsoleDebugger : public QDialog
 		void debugStepIntoCB(void);
 		void debugStepOutCB(void);
 		void debugStepOverCB(void);
+		void debugRunToCursorCB(void);
 		void debugRunLineCB(void);
 		void debugRunLine128CB(void);
 		void seekToCB(void);

--- a/src/drivers/Qt/config.cpp
+++ b/src/drivers/Qt/config.cpp
@@ -260,8 +260,10 @@ InitConfig()
 	config->addOption("hexEditFgColor", "SDL.HexEditFgColor", "#FFFFFF");
     
 	// Debugger Options
-	config->addOption("autoLoadDebugFiles", "SDL.AutoLoadDebugFiles", 1);
-	config->addOption("autoOpenDebugger"  , "SDL.AutoOpenDebugger"  , 0);
+	config->addOption("autoLoadDebugFiles"     , "SDL.AutoLoadDebugFiles", 1);
+	config->addOption("autoOpenDebugger"       , "SDL.AutoOpenDebugger"  , 0);
+	config->addOption("debuggerPCPlacementMode", "SDL.DebuggerPCPlacement"  , 0);
+	config->addOption("debuggerPCDLineOffset"  , "SDL.DebuggerPCLineOffset" , 0);
 
 	// Code Data Logger Options
 	config->addOption("autoSaveCDL"  , "SDL.AutoSaveCDL", 1);


### PR DESCRIPTION
Added breakpoint debugging 'Run to Cursor' and 'Run to Selected Line' features to Qt GUI. Added an option to the Qt debugger assembly view to allow for the positioning of the program counter line (when a breakpoint is hit) in the viewport to be configurable.