### PR TITLE
Bug fix for cmake pkg-config search for lua 5.1 package. Ubuntu packa…

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,10 +85,12 @@ else(WIN32)
   endif()
 
   # Check for LUA
-  pkg_check_modules( LUA lua-5.1)
+  pkg_search_module( LUA lua5.1 lua-5.1 )
 
   if ( ${LUA_FOUND} )
      # Use System LUA
+	  message( STATUS "Using System Lua ${LUA_VERSION}" )
+
 	  add_definitions( -D_S9XLUA_H  ${LUA_CFLAGS} )
 
 	  set( LUA_ENGINE_SOURCE  ${CMAKE_CURRENT_SOURCE_DIR}/lua-engine.cpp )
@@ -96,6 +98,8 @@ else(WIN32)
   else ()
 
      # Use Internal LUA
+	  message( STATUS "Using Internal Lua" )
+
      add_definitions( -D_S9XLUA_H  -I${CMAKE_CURRENT_SOURCE_DIR}/lua/src )
 
 	  set( LUA_ENGINE_SOURCE  


### PR DESCRIPTION
…ges this as lua5.1 and Fedora names it lua-5.1. Changed cmake file to use pkg_search_module to search for both package names and use the first one it finds. This addresses lua part of issue #246 