### PR TITLE
Save state fix - Prevent terminator for being added to SFMDATA

### DIFF
--- a/src/ines.cpp
+++ b/src/ines.cpp
@@ -1057,7 +1057,12 @@ static int iNES_Init(int num) {
 				}
 			}
 			if (head.ROM_type & 8)
-				AddExState(ExtraNTARAM, 2048, 0, "EXNR");
+			{
+				if (ExtraNTARAM != NULL)
+				{
+					AddExState(ExtraNTARAM, 2048, 0, "EXNR");
+				}
+			}
 			tmp->init(&iNESCart);
 			return 0;
 		}

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -860,6 +860,9 @@ void ResetExState(void (*PreSave)(void), void (*PostSave)(void))
 
 void AddExState(void *v, uint32 s, int type, const char *desc)
 {
+	//do not accept extra state information if a null pointer was provided for v, so list won't terminate early
+	if (v == 0) return;
+	
 	if(s==~0)
 	{
 		SFORMAT* sf = (SFORMAT*)v;


### PR DESCRIPTION
To fix a problem where the SFMDATA list gets terminated early, prevent NULL pointers from being added to the list.  This can be caused by `AddExState(ExtraNTARAM, 2048, 0, "EXNR");` with `ExtraNTARAM == NULL`.