### PR TITLE
Fix Load State for Mapper 19

### DIFF
--- a/src/boards/n106.cpp
+++ b/src/boards/n106.cpp
@@ -351,9 +351,9 @@ static void DoNamcoSound(int32 *Wave, int Count) {
 
 static void Mapper19_StateRestore(int version) {
 	SyncPRG();
+	SyncMirror();
 	FixNTAR();
 	FixCRR();
-	SyncMirror();
 	int x;
 	for (x = 0x40; x < 0x80; x++)
 		FixCache(x, IRAM[x]);


### PR DESCRIPTION
Fixes problems in Mappy Kids that makes it show the wrong nametable after loading state.

The function `SyncMirror` is breaking the nametables set by `FixNTAR`, so call `FixNTAR` second to get correct nametables again.