### PR TITLE
rename /bin/bash to /bin/sh to scripts in 'scripts folder

### DIFF
--- a/scripts/genGitHdr.sh
+++ b/scripts/genGitHdr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 OUTPUT_DIR=$1;
 

--- a/scripts/linux_makeIcons.sh
+++ b/scripts/linux_makeIcons.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 SRC_PNG=../fceux1.png
 ICON_PATH=/usr/share/icons/hicolor

--- a/scripts/unix_debug_build.sh
+++ b/scripts/unix_debug_build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 CLEAN_BUILD=0;
 MAKE_ARGS="";


### PR DESCRIPTION
The actions are needed to make sure that the scripts will work with other UNIX-like systems, as every single one of them has /bin/sh but not /bin/bash.