### PR TITLE
Using /usr/bin/env bash instead of /bin/bash

### DIFF
--- a/scripts/unix_debug_build.sh
+++ b/scripts/unix_debug_build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CLEAN_BUILD=0;
 MAKE_ARGS="";


### PR DESCRIPTION
```/bin/bash``` makes the script Linux-specific, so change it to ```/usr/bin/env bash```