### PR TITLE
add missing GL include needed on arm arch's

### DIFF
--- a/src/drivers/Qt/ConsoleViewerGL.cpp
+++ b/src/drivers/Qt/ConsoleViewerGL.cpp
@@ -28,6 +28,8 @@
 #include <QScreen>
 #include <QMouseEvent>
 
+#include <GL/gl.h>
+
 #include "Qt/nes_shm.h"
 #include "Qt/fceuWrapper.h"
 #include "Qt/ConsoleViewerGL.h"

--- a/src/drivers/Qt/ConsoleViewerGL.cpp
+++ b/src/drivers/Qt/ConsoleViewerGL.cpp
@@ -28,7 +28,9 @@
 #include <QScreen>
 #include <QMouseEvent>
 
+#if defined(__arm__) && defined(__linux__)
 #include <GL/gl.h>
+#endif
 
 #include "Qt/nes_shm.h"
 #include "Qt/fceuWrapper.h"


### PR DESCRIPTION
On other arch's, including amd64, this gets pulled in via QOpenGLWidget.
However, since it uses GL functions directly and GL.h doesn't get pulled in
automatically, this is necessary on arm.