### PR TITLE
honor standard build environment variables

### DIFF
--- a/fceux-server/Makefile
+++ b/fceux-server/Makefile
@@ -1,12 +1,12 @@
-PREFIX  = 	/usr
+PREFIX  ?= 	/usr
 OUTFILE = 	fceux-net-server
 
-CC	=	g++
+CXX	?=	g++
 OBJS	=	server.o md5.o throttle.o
 
 
 all:		${OBJS}
-		${CC} -o ${OUTFILE} ${OBJS}
+		${CXX} ${CXXFLAGS} -o ${OUTFILE} ${OBJS} ${LDFLAGS}
 
 clean:
 		rm -f ${OUTFILE} ${OBJS}


### PR DESCRIPTION
allow PREFIX to be overridden
use CXX for compiling C++ code, overriddable
include CXXFLAGS & LDFLAGS when compiling linking