### PR TITLE
fix: ppuViewer crashes the app when ROM is not opened

### DIFF
--- a/src/drivers/Qt/ppuViewer.cpp
+++ b/src/drivers/Qt/ppuViewer.cpp
@@ -1255,6 +1255,9 @@ static void DrawPatternTable( ppuPatternTable_t *pattern, uint8_t *table, uint8_
 	int p=0,tmp;
 	uint8_t chr0,chr1,logs,shift;
 
+	if (!palo)
+		return;
+
 	pal <<= 2;
 	for (i = 0; i < 16; i++)		//Columns
 	{


### PR DESCRIPTION
affected Qt build.
app version tested: 2.3.0-interim git
OS version: Ubuntu 20.04

steps to reproduce:

1) start application
2) menu Debug -> PPU Viewer...

in result SIGSEGV with call stack :
DrawPatternTable() - ppuViewer.cpp:1281
FCEUD_UpdatePPUView() - ppuViewer.cpp:1382
ppuViewerDialog_t::ppuViewerDialog_t() - ppuViewer.cpp:231
openPPUViewWindow() - ppuViewer.cpp:86
consoleWin_t::openPPUViewer() - ConsoleWindow.cpp:1497
... 

Function DrawPatternTable() uses global variable "palo" which is NULL until game isn't loaded.