### PR TITLE
Qt: GamePadConf change buttons sequentially.

### DIFF
--- a/src/drivers/Qt/GamePadConf.h
+++ b/src/drivers/Qt/GamePadConf.h
@@ -52,6 +52,10 @@ class GamePadConfDialog_t : public QDialog
 
       int  portNum;
       int  buttonConfigStatus;
+      int  changeSeqStatus; // status of sequentally changing buttons mechanism
+        //    0 - we can start new change process
+        // 1-10 - changing in progress
+        //   -1 - changing is aborted
 
       void changeButton( int port, int button );
       void clearButton( int port, int button );
@@ -98,6 +102,7 @@ class GamePadConfDialog_t : public QDialog
       void saveProfileCallback(void);
       void deleteProfileCallback(void);
 		void updatePeriodic(void);
+        void changeSequentallyCallback(void);
 
 };
 


### PR DESCRIPTION
By clicking "Change Sequentially" button now it's possible to setup gamepad only by pressing buttons on GamePad and not bothering to press "Change" button for each gamepad's button which you trying to associate.

Demonstration on video:
https://user-images.githubusercontent.com/1304776/107129750-be4eec00-68d8-11eb-9f53-c0ed28cee671.mp4

