### PR TITLE
Fixes regarding RAM Search and RAM Watch dialogs.

### DIFF
--- a/src/drivers/Qt/RamSearch.cpp
+++ b/src/drivers/Qt/RamSearch.cpp
@@ -1243,7 +1243,14 @@ void RamSearchDialog_t::addRamWatchClicked(void)
    }
    strcpy( desc, "Quick Watch Add");
 
-   ramWatchList.add_entry( desc, addr, dpyType, dpySize, 0 );
+   int size = 1;
+   switch (dpySize) {
+   case 'd': size = 4; break;
+   case 'w': size = 2; break;
+   case 'b': size = 1; break;
+   default: break;
+   }
+   ramWatchList.add_entry( desc, addr, dpyType, size, 0 );
 
    openRamWatchWindow(consoleWindow);
 }

--- a/src/drivers/Qt/RamWatch.cpp
+++ b/src/drivers/Qt/RamWatch.cpp
@@ -730,9 +730,12 @@ void ramWatch_t::updateMem (void)
 	{
 		val.u16 = (GetMem (addr) << 8) | GetMem (addr + 1);
 	}
-	else
+	else if (size == 4)
 	{
-		val.u8 = GetMem (addr);
+		val.u32  = GetMem (addr + 3);
+		val.u32 |= GetMem (addr + 2) << 8;
+		val.u32 |= GetMem (addr + 1) << 16;
+		val.u32 |= GetMem (addr    ) << 24;
 	}
 }
 //------------------------------------------------------------------------.----

--- a/src/drivers/Qt/RamWatch.cpp
+++ b/src/drivers/Qt/RamWatch.cpp
@@ -728,14 +728,14 @@ void ramWatch_t::updateMem (void)
 	}
 	else if (size == 2)
 	{
-		val.u16 = GetMem (addr) | (GetMem (addr + 1) << 8);
+		val.u16 = (GetMem (addr) << 8) | GetMem (addr + 1);
 	}
 	else
 	{
 		val.u8 = GetMem (addr);
 	}
 }
-//----------------------------------------------------------------------------
+//------------------------------------------------------------------------.----
 void RamWatchDialog_t::openWatchEditWindow( ramWatch_t *rw, int mode)
 {
 	int ret, isSep = 0;


### PR DESCRIPTION
1)  Invalid size of watch region after adding it from RAM Search dialog.
2)  Endianness of 2 byte value not same for same address in RAM Search and RAM Watch dialogs.
3)  RAM Watch dialog not support 4 byte values.