### PR TITLE
For Qt version: Cheat codes with addresses ending in '0' are getting truncated. This …

### DIFF
--- a/src/drivers/Qt/CheatsConf.cpp
+++ b/src/drivers/Qt/CheatsConf.cpp
@@ -859,7 +859,7 @@ void GuiCheatsDialog_t::addActvCheat(void)
 
 	a = strtoul(cheatAddrEntry->displayText().toStdString().c_str(), NULL, 16);
 
-	v = strtoul(cheatValEntry->text().toStdString().c_str(), NULL, 16);
+	v = strtoul(cheatValEntry->displayText().toStdString().c_str(), NULL, 16);
 
 	cmpStr = cheatCmpEntry->text().toStdString();
 
@@ -933,7 +933,7 @@ void GuiCheatsDialog_t::updateCheatParameters(void)
 
 	a = strtoul(cheatAddrEntry->displayText().toStdString().c_str(), NULL, 16);
 
-	v = strtoul(cheatValEntry->text().toStdString().c_str(), NULL, 16);
+	v = strtoul(cheatValEntry->displayText().toStdString().c_str(), NULL, 16);
 
 	cmpStr = cheatCmpEntry->text().toStdString();
 

--- a/src/drivers/Qt/CheatsConf.cpp
+++ b/src/drivers/Qt/CheatsConf.cpp
@@ -857,7 +857,7 @@ void GuiCheatsDialog_t::addActvCheat(void)
 	int c = -1;
 	std::string name, cmpStr;
 
-	a = strtoul(cheatAddrEntry->text().toStdString().c_str(), NULL, 16);
+	a = strtoul(cheatAddrEntry->displayText().toStdString().c_str(), NULL, 16);
 
 	v = strtoul(cheatValEntry->text().toStdString().c_str(), NULL, 16);
 
@@ -931,7 +931,7 @@ void GuiCheatsDialog_t::updateCheatParameters(void)
 	}
 	//printf("Row: %i \n", row );
 
-	a = strtoul(cheatAddrEntry->text().toStdString().c_str(), NULL, 16);
+	a = strtoul(cheatAddrEntry->displayText().toStdString().c_str(), NULL, 16);
 
 	v = strtoul(cheatValEntry->text().toStdString().c_str(), NULL, 16);
 


### PR DESCRIPTION
…is due to the masking at line 141 (cheatAddrEntry->setInputMask( ">HHHH;0" );) combined with

cheatAddrEntry->displayText() on 860/934.
As per: https://doc.qt.io/qt-5/qlineedit.html#inputMask-prop

"When an input mask is set, the text() method returns a modified copy of the line edit content where all the blank characters have been removed.
The unmodified content can be read using displayText()."

So an address of "00B0" is returning as just "B"(as the mask as determined that 0 is a blank character. Which is what you want for an empty input
 field to have all 0;s.), which, when entered as an address, is just 0x000B. Fixing that by replacing text() with displayText() as
per documentation.