### PR TITLE
Grayscale filter fix

### DIFF
--- a/src/drivers/Qt/sdl-video.cpp
+++ b/src/drivers/Qt/sdl-video.cpp
@@ -51,7 +51,6 @@
 
 // GLOBALS
 extern Config *g_config;
-extern bool force_grayscale;
 
 // STATIC GLOBALS
 static int s_curbpp = 0;
@@ -363,21 +362,9 @@ FCEUD_SetPalette(uint8 index,
                  uint8 g,
                  uint8 b)
 {
-	if ( force_grayscale )
-	{
-		// convert the palette entry to grayscale
-		int gray = ((float)r * 0.299 + (float)g * 0.587 + (float)b * 0.114);
-
-		s_psdl[index].r = gray;
-		s_psdl[index].g = gray;
-		s_psdl[index].b = gray;
-	}
-	else
-	{
-		s_psdl[index].r = r;
-		s_psdl[index].g = g;
-		s_psdl[index].b = b;
-	}
+	s_psdl[index].r = r;
+	s_psdl[index].g = g;
+	s_psdl[index].b = b;
 
 	s_paletterefresh = 1;
 }

--- a/src/drivers/win/video.cpp
+++ b/src/drivers/win/video.cpp
@@ -115,19 +115,9 @@ int RestoreDD(int w)
 
 void FCEUD_SetPalette(unsigned char index, unsigned char r, unsigned char g, unsigned char b)
 {
-	if (force_grayscale)
-	{
-		// convert the palette entry to grayscale
-		int gray = ((float)r * 0.299 + (float)g * 0.587 + (float)b * 0.114);
-		color_palette[index].peRed = gray;
-		color_palette[index].peGreen = gray;
-		color_palette[index].peBlue = gray;
-	} else
-	{
-		color_palette[index].peRed = r;
-		color_palette[index].peGreen = g;
-		color_palette[index].peBlue = b;
-	}
+	color_palette[index].peRed = r;
+	color_palette[index].peGreen = g;
+	color_palette[index].peBlue = b;
 	PaletteChanged=1;
 }
 

--- a/src/palette.cpp
+++ b/src/palette.cpp
@@ -532,9 +532,9 @@ static void ChoosePalette(void)
 		// need to apply grayscale filter
 		// allocate memory for grayscale palette
 		if (grayscaled_palo == NULL)
-			grayscaled_palo = (pal*)malloc(sizeof(pal) * 512);
+			grayscaled_palo = (pal*)malloc(sizeof(pal) * 64 * 8);
 		// make every color grayscale
-		for (int x = 0; x < 512; x++)
+		for (int x = 0; x < 64 * 8; x++)
 		{
 			uint8 gray = ((float)palo[x].r * 0.299 + (float)palo[x].g * 0.587 + (float)palo[x].b * 0.114);
 			grayscaled_palo[x].r = gray;
@@ -546,6 +546,7 @@ static void ChoosePalette(void)
 	}
 	else if (grayscaled_palo != NULL)
 	{
+		// free allocated memory if the grayscale filter is not used anymore
 		free(grayscaled_palo);
 		grayscaled_palo = NULL;
 	}

--- a/src/palette.cpp
+++ b/src/palette.cpp
@@ -41,6 +41,7 @@
 #include <cstring>
 
 bool force_grayscale = false;
+pal *grayscaled_palo = NULL;
 
 pal palette_game[64*8]; //custom palette for an individual game. (formerly palettei)
 pal palette_user[64*8]; //user's overridden palette (formerly palettec)
@@ -525,6 +526,28 @@ static void ChoosePalette(void)
 		palo = default_palette[default_palette_selection];
 		//need to calcualte a deemph on the fly.. sorry. maybe support otherwise later
 		ApplyDeemphasisComplete(palo);
+	}
+	if (force_grayscale)
+	{
+		// need to apply grayscale filter
+		// allocate memory for grayscale palette
+		if (grayscaled_palo == NULL)
+			grayscaled_palo = (pal*)malloc(sizeof(pal) * 512);
+		// make every color grayscale
+		for (int x = 0; x < 512; x++)
+		{
+			uint8 gray = ((float)palo[x].r * 0.299 + (float)palo[x].g * 0.587 + (float)palo[x].b * 0.114);
+			grayscaled_palo[x].r = gray;
+			grayscaled_palo[x].g = gray;
+			grayscaled_palo[x].b = gray;
+		}
+		// apply new palette
+		palo = grayscaled_palo;
+	}
+	else if (grayscaled_palo != NULL)
+	{
+		free(grayscaled_palo);
+		grayscaled_palo = NULL;
 	}
 }
 


### PR DESCRIPTION
# Fix for #363

I moved the grayscale filter code from both `Qt/sdl-video.cpp` and `win/video.cpp` to `ChoosePalette()` in `palette.cpp`:

```C++
if (force_grayscale)
{
	// need to apply grayscale filter
	// allocate memory for grayscale palette
	if (grayscaled_palo == NULL)
		grayscaled_palo = (pal*)malloc(sizeof(pal) * 64 * 8);
	// make every color grayscale
	for (int x = 0; x < 64 * 8; x++)
	{
		uint8 gray = ((float)palo[x].r * 0.299 + (float)palo[x].g * 0.587 + (float)palo[x].b * 0.114);
		grayscaled_palo[x].r = gray;
		grayscaled_palo[x].g = gray;
		grayscaled_palo[x].b = gray;
	}
	// apply new palette
	palo = grayscaled_palo;
}
else if (grayscaled_palo != NULL)
{
	// free allocated memory if the grayscale filter is not used anymore
	free(grayscaled_palo);
	grayscaled_palo = NULL;
}
```

So:
* The force grayscale feature now works for all 512 colors (e.g. when emphasis bits are set)
* Grayscale palette calculated only once, when a palette selected
* This code is not duplicated for Windows and Qt
