### PR TITLE
Make reset and power cycle bindable to game pad.

### DIFF
--- a/src/drivers/Qt/GamePadConf.cpp
+++ b/src/drivers/Qt/GamePadConf.cpp
@@ -348,6 +348,8 @@ GamePadConfDialog_t::GamePadConfDialog_t(QWidget *parent)
 	connect(button[7], SIGNAL(clicked()), this, SLOT(changeButton7(void)));
 	connect(button[8], SIGNAL(clicked()), this, SLOT(changeButton8(void)));
 	connect(button[9], SIGNAL(clicked()), this, SLOT(changeButton9(void)));
+	connect(button[10], SIGNAL(clicked()), this, SLOT(changeButton10(void)));
+	connect(button[11], SIGNAL(clicked()), this, SLOT(changeButton11(void)));
 
 	connect(clearButton[0], SIGNAL(clicked()), this, SLOT(clearButton0(void)));
 	connect(clearButton[1], SIGNAL(clicked()), this, SLOT(clearButton1(void)));
@@ -359,6 +361,8 @@ GamePadConfDialog_t::GamePadConfDialog_t(QWidget *parent)
 	connect(clearButton[7], SIGNAL(clicked()), this, SLOT(clearButton7(void)));
 	connect(clearButton[8], SIGNAL(clicked()), this, SLOT(clearButton8(void)));
 	connect(clearButton[9], SIGNAL(clicked()), this, SLOT(clearButton9(void)));
+	connect(clearButton[10], SIGNAL(clicked()), this, SLOT(clearButton10(void)));
+	connect(clearButton[11], SIGNAL(clicked()), this, SLOT(clearButton11(void)));
 
 	connect(newProfileButton, SIGNAL(clicked()), this, SLOT(newProfileCallback(void)));
 	connect(applyProfileButton, SIGNAL(clicked()), this, SLOT(loadProfileCallback(void)));
@@ -933,6 +937,16 @@ void GamePadConfDialog_t::changeButton9(void)
 	changeButton(portNum, 9);
 }
 //----------------------------------------------------
+void GamePadConfDialog_t::changeButton10(void)
+{
+	changeButton(portNum, 10);
+}
+//----------------------------------------------------
+void GamePadConfDialog_t::changeButton11(void)
+{
+	changeButton(portNum, 11);
+}
+//----------------------------------------------------
 void GamePadConfDialog_t::clearButton0(void)
 {
 	clearButton(portNum, 0);
@@ -981,6 +995,16 @@ void GamePadConfDialog_t::clearButton8(void)
 void GamePadConfDialog_t::clearButton9(void)
 {
 	clearButton(portNum, 9);
+}
+//----------------------------------------------------
+void GamePadConfDialog_t::clearButton10(void)
+{
+	clearButton(portNum, 10);
+}
+//----------------------------------------------------
+void GamePadConfDialog_t::clearButton11(void)
+{
+	clearButton(portNum, 11);
 }
 //----------------------------------------------------
 void GamePadConfDialog_t::clearAllCallback(void)

--- a/src/drivers/Qt/GamePadConf.h
+++ b/src/drivers/Qt/GamePadConf.h
@@ -219,6 +219,8 @@ private slots:
 	void changeButton7(void);
 	void changeButton8(void);
 	void changeButton9(void);
+	void changeButton10(void);
+	void changeButton11(void);
 	void clearButton0(void);
 	void clearButton1(void);
 	void clearButton2(void);
@@ -229,6 +231,8 @@ private slots:
 	void clearButton7(void);
 	void clearButton8(void);
 	void clearButton9(void);
+	void clearButton10(void);
+	void clearButton11(void);
 	void clearAllCallback(void);
 	void ena4score(int state);
 	void oppDirEna(int state);

--- a/src/drivers/Qt/input.cpp
+++ b/src/drivers/Qt/input.cpp
@@ -1476,6 +1476,18 @@ UpdateGamepad(void)
 				}
 			}
 		}
+		if (DTestButton(&GamePad[wg].bmap[10])) {
+		  // reset
+		  fceuWrapperLock();
+		  fceuWrapperSoftReset();
+		  fceuWrapperUnLock();
+		}
+		if (DTestButton(&GamePad[wg].bmap[11])) {
+		  // power cycle
+		  fceuWrapperLock();
+		  fceuWrapperHardReset();
+		  fceuWrapperUnLock();
+		}
 	}
 
 	//  for(x=0;x<32;x+=8)      /* Now, test to see if anything weird(up+down at same time)
@@ -2763,15 +2775,15 @@ void UpdateInput(Config *config)
 // Definitions from main.h:
 // GamePad defaults
 const char *GamePadNames[GAMEPAD_NUM_BUTTONS] = {"A", "B", "Select", "Start",
-												 "Up", "Down", "Left", "Right", "TurboA", "TurboB"};
+						 "Up", "Down", "Left", "Right", "TurboA", "TurboB", "Reset", "PowerCycle"};
 const char *DefaultGamePadDevice[GAMEPAD_NUM_DEVICES] =
 	{"Keyboard", "None", "None", "None"};
 const int DefaultGamePad[GAMEPAD_NUM_DEVICES][GAMEPAD_NUM_BUTTONS] =
 	{{SDLK_f, SDLK_d, SDLK_s, SDLK_RETURN,
-	  SDLK_UP, SDLK_DOWN, SDLK_LEFT, SDLK_RIGHT, -1, -1},
-	 {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1},
-	 {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1},
-	 {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1}};
+	  SDLK_UP, SDLK_DOWN, SDLK_LEFT, SDLK_RIGHT, -1, -1, -1, -1},
+	 {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1},
+	 {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1},
+	 {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1}};
 
 // PowerPad defaults
 const char *PowerPadNames[POWERPAD_NUM_BUTTONS] =

--- a/src/drivers/Qt/main.h
+++ b/src/drivers/Qt/main.h
@@ -49,7 +49,7 @@ int CLImain(int argc, char *argv[]);
 
 // GamePad defaults
 #define GAMEPAD_NUM_DEVICES 4
-#define GAMEPAD_NUM_BUTTONS 10
+#define GAMEPAD_NUM_BUTTONS 12
 extern const char *GamePadNames[GAMEPAD_NUM_BUTTONS];
 extern const char *DefaultGamePadDevice[GAMEPAD_NUM_DEVICES];
 extern const int DefaultGamePad[GAMEPAD_NUM_DEVICES][GAMEPAD_NUM_BUTTONS];

--- a/src/drivers/Qt/sdl-joystick.cpp
+++ b/src/drivers/Qt/sdl-joystick.cpp
@@ -46,7 +46,7 @@ static const char *buttonNames[GAMEPAD_NUM_BUTTONS] =
 	{
 		"a", "b", "back", "start",
 		"dpup", "dpdown", "dpleft", "dpright",
-		"turboA", "turboB"};
+		"turboA", "turboB", "reset", "powerCycle"};
 
 //********************************************************************************
 // Joystick Device


### PR DESCRIPTION
Makes soft reset and hard reset (power cycle) bindable to gamepad buttons in the Qt UI.

Using resets to manipulate RNG is an important tactic in Final Fantasy Randomizer speedrunning, it may be useful for other games as well.
