### PR TITLE
Fix on OpenBSD

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -132,7 +132,13 @@ else(WIN32)
 	set( OPENGL_LDFLAGS  "-framework OpenGL" )
   else()
 	set( OPENGL_LDFLAGS  ${OPENGL_LIBRARIES} )
-  	set( SYS_LIBS  -lrt  -lpthread  -ldl)
+	# OpenBSD  refuses  to  implement  the POSIX  realtime  interface  and
+	# refuses to provide a stub library for -ldl
+	if(${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
+	  	set( SYS_LIBS  -lpthread)
+        else()
+          	set( SYS_LIBS  -lrt  -lpthread  -ldl)
+        endif()
   endif()
 
 endif(WIN32)

--- a/src/drivers/Qt/ConsoleWindow.cpp
+++ b/src/drivers/Qt/ConsoleWindow.cpp
@@ -4086,7 +4086,7 @@ int consoleWin_t::getSchedParam( int &policy, int &priority )
 {
 	int ret = 0;
 
-#if defined(__linux__) || defined(__unix__)
+#if defined(__linux__) || defined(__unix__) && !defined(__OpenBSD__)
 	struct sched_param  p;
 
 	policy = sched_getscheduler( getpid() );
@@ -4122,7 +4122,7 @@ int consoleWin_t::getSchedParam( int &policy, int &priority )
 int consoleWin_t::setSchedParam( int policy, int priority )
 {
 	int ret = 0;
-#if defined(__linux__) || defined(__unix__)
+#if defined(__linux__) || defined(__unix__) && !defined(__OpenBSD__)
 	struct sched_param  p;
 	int minPrio, maxPrio;
 


### PR DESCRIPTION
OpenBSD doesn't implement the scheduler interface, so disable use of that if on OpenBSD. It also doesn't provide -lrt (which provides the scheduler interface,) nor a dummy -ldl (whose functions are provided with just libc.)