### PR TITLE
Fix "OVERFLOW" byte not being shown at address $FFFF.

### DIFF
--- a/src/drivers/win/debugger.cpp
+++ b/src/drivers/win/debugger.cpp
@@ -687,7 +687,7 @@ void Disassemble(HWND hWnd, int id, int scrollid, unsigned int addr)
 		{
 			if ((addr + size) > 0xFFFF)
 			{
-				while (addr < 0xFFFF)
+				while (addr <= 0xFFFF)
 				{
 					swprintf(chr, L"%02X        OVERFLOW\n", GetMem(addr++));
 					wcscat(debug_wstr, chr);
@@ -1901,7 +1901,7 @@ BOOL CALLBACK IDC_DEBUGGER_DISASSEMBLY_WndProc(HWND hwndDlg, UINT uMsg, WPARAM w
 					if (GetNesFileAddress(i) == -1)
 						sprintf(str,"CPU Address $%04X, Error retreiving ROM File Address!",i);
 					else
-						sprintf(str,"CPU Address %02X:%04X, Offset 0x%06X in file \"%.40s%s\" (NL file: %X)",getBank(i),i,GetNesFileAddress(i),ptr,dotdot,getBank(i));
+						sprintf(str,"CPU Address %02X:%04X, Offset 0x%06X in file \"%.40s%s\"",getBank(i),i,GetNesFileAddress(i),ptr,dotdot);
 					SetDlgItemText(hDebug, IDC_DEBUGGER_ADDR_LINE,str);
 				} else
 				{


### PR DESCRIPTION
Also removes "NL File" in the status line, whatever that was supposed to be. It's just the bank number, which is already part of the address.