### PR TITLE
Mapper 19/210 fixes

### DIFF
--- a/src/ines.cpp
+++ b/src/ines.cpp
@@ -548,7 +548,7 @@ BMAPPINGLocal bmap[] = {
 	{"BANDAI 24C02",		 16, Mapper16_Init},
 	{"FFE Rev. B",			 17, Mapper17_Init},
 	{"JALECO SS88006",		 18, Mapper18_Init},	// JF-NNX (EB89018-30007) boards
-	{"Namcot 106",			 19, Mapper19_Init},
+	{"NAMCOT 163",			 19, Mapper19_Init},
 //	{"",					 20, Mapper20_Init},
 	{"Konami VRC2/VRC4 A",	 21, Mapper21_Init},
 	{"Konami VRC2/VRC4 B",	 22, Mapper22_Init},
@@ -739,7 +739,7 @@ BMAPPINGLocal bmap[] = {
 	{"TAITO X1-005 Rev. B",	207, Mapper207_Init},
 	{"",					208, Mapper208_Init},
 	{"",					209, Mapper209_Init},
-	{"",					210, Mapper210_Init},
+	{"NAMCOT 175/340",		210, Mapper210_Init},
 	{"",					211, Mapper211_Init},
 	{"",					212, Mapper212_Init},
 	{"",					213, Mapper213_Init},


### PR DESCRIPTION
Various fixes for the later Namco mappers:

Add missing battery backup initialization to Mapper 210. Fixes #814

Fix mirroring settings in Mapper 210. Fixes #815

Add NES 2.0 submappers to Mapper 210 (submapper 1 with hardwired mirroring, submapper 2 with mapper-controlled mirroring) with fallback detection by CRC32. I'm not sure if any games actually need this; all the games on PCBs with hardwired mirroring seem to set the mirroring register bits correctly anyway, but it's nice to be accurate.

Implement Mapper 19's capability to map pages of the console's nametable RAM as CHR RAM (based on Mapper 218 implementation; untested because I don't know which if any games use it)