### PR TITLE
cmake: fix qt6 build on linux/macOS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,8 +47,6 @@ if ( ${QT} EQUAL 6 )
 	find_package( Qt6 COMPONENTS Help QUIET)
 	find_package( Qt6 COMPONENTS Qml)
 	find_package( Qt6 COMPONENTS UiTools)
-	add_definitions( ${Qt6Widgets_DEFINITIONS} ${Qt6Qml_DEFINITIONS} ${Qt6Network_DEFINITIONS} ${Qt6Help_DEFINITIONS} ${Qt6OpenGLWidgets_DEFINITIONS} )
-	# add_definitions(${Qt6UiTools_DEFINITIONS}) # Leave ${Qt6UiTools_DEFINITIONS} out as this is causing a build error
 	include_directories( ${Qt6Widgets_INCLUDE_DIRS} ${Qt6Qml_INCLUDE_DIRS} ${Qt6UiTools_INCLUDE_DIRS} ${Qt6Network_INCLUDE_DIRS} ${Qt6Help_INCLUDE_DIRS} ${Qt6OpenGLWidgets_INCLUDE_DIRS} )
 
 	if (${Qt6Help_FOUND})
@@ -756,6 +754,11 @@ target_link_libraries( ${APP_NAME}
 	${LUA_LDFLAGS} ${X264_LDFLAGS} ${X265_LDFLAGS} ${LIBAV_LDFLAGS}
  	${SYS_LIBS}
 )
+
+if(NOT MSVC)
+	# Add minizip subdirectory so #include<unzip.h> works without the "minizip" subdirectory in the directive
+	target_include_directories(${APP_NAME} PRIVATE ${MINIZIP_INCLUDE_DIRS}/minizip)
+endif()
 
 if (WIN32)
 	#   target_link_libraries( ${APP_NAME} wsock32 ws2_32 )


### PR DESCRIPTION
There seems to currently be two issues that prevent successful fceux compilation on Linux and macOS

1. This cmake `add_definitions()` call is no longer necessary for Qt6 - it actually expands macros that prevent the build from working:
```
    add_definitions( ${Qt6Widgets_DEFINITIONS} ${Qt6Qml_DEFINITIONS} ${Qt6Network_DEFINITIONS} ${Qt6Help_DEFINITIONS} ${Qt6OpenGLWidgets_DEFINITIONS} )
```

Ninja will refuse to even start to build.  Using "Unix Makefiles"
```bash
$ ninja -C build --verbose
ninja: Entering directory `build'
ninja: error: build.ninja:127: bad $-escape (literal $ must be written as $$)
  FLAGS = -g   $<$<AND:$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>,$<...
               ^ near here
```

Unix Makefiles will get a little farther before failing:

```bash
cmake -B build -G "Unix Makefiles"

# ...

$ make -C build
make: Entering directory '/home/lukas/tmp/fceux/build'
[  0%] Built target fceux_autogen_timestamp_deps
[  1%] Automatic MOC and UIC for target fceux
AutoMoc: /home/lukas/tmp/fceux/src/drivers/Qt/HelpPages.h: note: No relevant classes found. No output generated.
[  1%] Built target fceux_autogen
[  1%] Generating fceux_git_info.cpp
Output File: /home/lukas/tmp/fceux/build/src/fceux_git_info.cpp
Git URL: git@github.com:TASEmulators/fceux.git
Git Rev: 1e1168db6662ce86848460b5d078e17c6dc6e2ce
Generated /home/lukas/tmp/fceux/build/src/fceux_git_info.cpp
[  1%] Automatic RCC for ../resources.qrc
[  2%] Building CXX object src/CMakeFiles/fceux.dir/fceux_autogen/mocs_compilation.cpp.o
/bin/sh: -c: line 1: syntax error near unexpected token `>'
/bin/sh: -c: line 1: `cd /home/lukas/tmp/fceux/build/src && /usr/bin/c++ -DFCEUDEF_DEBUGGER -DFCEUX_BUILD_TIMESTAMP="\"16:54:38  Apr 19 2026\"" -DHAVE_ASPRINTF
-DLUA_USE_LINUX -DQT_CORE_LIB -DQT_DBUS_LIB -DQT_DEPRECATED_WARNINGS -DQT_GUI_LIB -DQT_HELP_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_OPENGLWIDGETS_LIB -DQT_OPENGL_LIB -DQT_QMLINTEGRATION_LIB -DQT_QML_LIB -DQT_SQL_LIB -DQT_UITOOLS_LIB -DQT_WIDGETS_LIB -DX264_API_IMPORTS -D_GNU_SOURCE=1 -D_HAS_X11 -D_HAS_XKB -D_REENTRANT
-D_S9XLUA_H -D_SYSTEM_MINIZIP -D_USE_LIBARCHIVE -D_USE_LIBAV -D_USE_X264 -D_USE_X265 -D__FCEU_QNETWORK_ENABLE__ -D__FCEU_QSCRIPT_ENABLE__ -D__QT_DRIVER__ -D__QT_UI_TOOLS__ -D__SDL__ -I/home/lukas/tmp/fceux/build/src/fceux_autogen/include -I/usr/include/qt6/QtDBus -I/usr/include/qt6/QtUiPlugin -I/home/lukas/tmp/fceux/src -I/home/lukas/tmp/fceux/src/drivers -isystem /usr/include/qt6/QtWidgets -isystem /usr/include/qt6 -isystem /usr/include/qt6/QtCore -isystem /usr/include/qt6/QtGui -isystem /usr/include/qt6/QtQml -isystem /usr/include/qt6/QtQmlIntegration -isystem /usr/include/qt6/QtNetwork -isystem /usr/include/qt6/QtUiTools -isystem /usr/include/qt6/QtOpenGLWidgets -isystem /usr/include/qt6/QtOpenGL -isystem /usr/include/qt6/QtHelp -isystem /usr/include/qt6/QtSql -isystem /usr/lib/qt6/mkspecs/linux-g++ src/CMakeFiles/fceux.dir/compiler_depend.tssrc/CMakeFiles/fceux.dir/compiler_depend.tsAND:src/CMakeFiles/fceux.dir/compiler_depend.tsSTREQUAL:src/CMakeFiles/fceux.dir/compiler_depend.tsTARGET_PROPERTY:TYPE>,EXECUTABLE>,src/CMakeFiles/fceux.dir/compiler_depend.tsBOOL:src/CMakeFiles/fceux.dir/compiler_depend.tsTARGET_PROPERTY:QT_ENABLE_QML_DEBUG>>>:QT_QML_DEBUG> -Wall -Wno-write-strings -Wno-parentheses -Wno-unused-local-typedefs -fPIC -I/usr/include -I/usr/include -I/usr/include -I/usr/include -I/usr/include -I/usr/include -I/usr/include -I/usr/include/SDL2 -I/home/lukas/tmp/fceux/src/lua/src -mno-direct-extern-access -MD -MT src/CMakeFiles/fceux.dir/fceux_autogen/mocs_compilation.cpp.o -MF CMakeFiles/fceux.dir/fceux_autogen/mocs_compilation.cpp.o.d -o CMakeFiles/fceux.dir/fceux_autogen/mocs_compilation.cpp.o -c /home/lukas/tmp/fceux/build/src/fceux_autogen/mocs_compilation.cpp'
make[2]: *** [src/CMakeFiles/fceux.dir/build.make:127: src/CMakeFiles/fceux.dir/fceux_autogen/mocs_compilation.cpp.o] Error 2
make[1]: *** [CMakeFiles/Makefile2:109: src/CMakeFiles/fceux.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

2. Minizip headers were not being found.  Fceux uses `#include <unzip.h>` instead of `#include <minizip/unzip.h>`, so the minizip subdirectory must be manually added to the include directives:

```
target_include_directories(${APP_NAME} PRIVATE ${MINIZIP_INCLUDE_DIRS}/minizip)
```

With these `CMakeLists.txt` changes in place, fceux successfully compiles on Linux (tested with Arch Linux 64) and macOS (tested with Tahoe 26.4.1)

Let me know if anyone has any comments or questions